### PR TITLE
Use System.nanoTime() instead of System.currentTimeMillis()

### DIFF
--- a/src/main/java/com/amazon/corretto/benchmark/heapothesys/TaskBase.java
+++ b/src/main/java/com/amazon/corretto/benchmark/heapothesys/TaskBase.java
@@ -54,12 +54,12 @@ public abstract class TaskBase {
             final long rate = rateInMb * 1024 * 1024;
             final ArrayDeque<AllocObject> survivorQueue = new ArrayDeque<>();
 
-            final long end = System.currentTimeMillis() + durationInMs;
+            final long end = System.nanoTime() + durationInMs * 1000000;
             final TokenBucket throughput = new TokenBucket(rate);
             int longLivedRate = MAX_LONG_LIVED_RATIO;
             int longLivedCounter = longLivedRate;
 
-            while (System.currentTimeMillis() < end) {
+            while (System.nanoTime() < end) {
                 long wave = 0L;
                 while (wave < rate / 10) {
                     if (!throughput.isThrottled()) {


### PR DESCRIPTION
*Issue #, if available:* 

#23 

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
