### PR TITLE
Use FixedThreadPool instead of CachedThreadPool in SimpleRunner.java.

### DIFF
--- a/src/main/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunner.java
+++ b/src/main/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunner.java
@@ -30,7 +30,7 @@ public class SimpleRunner extends TaskBase {
             final ObjectStore store = new ObjectStore(config.getLongLivedInMb(), config.getPruneRatio(),
                     config.getReshuffleRatio());
             new Thread(store).start();
-            final ExecutorService executor = Executors.newCachedThreadPool();
+            final ExecutorService executor = Executors.newFixedThreadPool(config.getNumOfThreads());
             final List<Future<Long>> results = executor.invokeAll(createTasks(store));
 
             long sum = 0;


### PR DESCRIPTION
*Issue #, if available:*

#27 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
