### PR TITLE
Bug: Add objects at the end of survivor queue and change queueSize calculation to avoid int overflow

### DIFF
--- a/src/main/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunner.java
+++ b/src/main/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunner.java
@@ -71,9 +71,9 @@ public class SimpleRunner extends TaskBase {
     }
 
     private List<Callable<Long>> createTasks(final ObjectStore store) {
-        final int queueSize = config.getMidAgedInMb() * 1024 * 1024 * 2
+        final int queueSize = (int)(config.getMidAgedInMb() * 1024L * 1024L * 2L
                 / (config.getMaxObjectSize() + config.getMinObjectSize())
-                / config.getNumOfThreads();
+                / config.getNumOfThreads());
 
         return IntStream.range(0, config.getNumOfThreads())
                 .mapToObj(i -> createSingle(store, config.getAllocRateInMbPerSecond() / config.getNumOfThreads(),

--- a/src/main/java/com/amazon/corretto/benchmark/heapothesys/TaskBase.java
+++ b/src/main/java/com/amazon/corretto/benchmark/heapothesys/TaskBase.java
@@ -66,7 +66,7 @@ public abstract class TaskBase {
                         final AllocObject obj = AllocObject.create(minObjectSize, maxObjectSize, null);
                         throughput.deduct(obj.getRealSize());
                         wave += obj.getRealSize();
-                        survivorQueue.push(obj);
+                        survivorQueue.addLast(obj);
 
                         if (survivorQueue.size() > queueLength) {
                             final AllocObject removed = survivorQueue.poll();


### PR DESCRIPTION
*Issue:* #30 and #32 

*Description of changes:*
1. Instead of adding objects at the front of the survivor queue, objects are added at the back of the survivor queue. Objects added at the back and removed from the front of the queue ensures that the youngest objects are always maintained in the queue.
*Note* - Ran heapothesys with the same args mentioned in issue #30  after making the change. -m option is working as expected, can be confirmed from the attached logs. [good_case.txt](https://github.com/corretto/heapothesys/files/4837271/good_case.txt)
2.  Change queueSize calculation in SimpleRunner.java->createTasks to avoid int overflow and negative queueSize for -m >=1024. (#32)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
