### PR TITLE
Use System Lambda instead of System Rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
             </dependency>
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-rules</artifactId>
-                <version>1.19.0</version>
+                <artifactId>system-lambda</artifactId>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
+            <artifactId>system-lambda</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/test/java/com/amazon/corretto/benchmark/heapothesys/HypothesysTest.java
+++ b/src/test/java/com/amazon/corretto/benchmark/heapothesys/HypothesysTest.java
@@ -1,12 +1,12 @@
 package com.amazon.corretto.benchmark.heapothesys;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class HypothesysTest {
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void SimpleRunTest() {
@@ -19,8 +19,9 @@ public class HypothesysTest {
     }
 
     @Test
-    public void UnknownRunTypeTest() {
-        exit.expectSystemExitWithStatus(1);
-        Heapothesys.main(new String[]{"-u", "unknown", "-a", "5"});
+    public void UnknownRunTypeTest() throws Exception {
+        int status = catchSystemExit(
+                () -> Heapothesys.main(new String[]{"-u", "unknown", "-a", "5"}));
+        assertThat(status, is(1));
     }
 }

--- a/src/test/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunConfigTest.java
+++ b/src/test/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunConfigTest.java
@@ -1,10 +1,10 @@
 package com.amazon.corretto.benchmark.heapothesys;
 
-import org.junit.Rule;
 import org.junit.Test;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 public class SimpleRunConfigTest {
     @Test
@@ -66,13 +66,11 @@ public class SimpleRunConfigTest {
         assertFalse(config.isUseCompressedOops());
     }
 
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-
     @Test
-    public void UnknownParameterShouldExitTest() {
-        exit.expectSystemExitWithStatus(1);
+    public void UnknownParameterShouldExitTest() throws Exception {
+        int status = catchSystemExit(
+                () -> new SimpleRunConfig(new String[]{"-w", "who"}));
 
-        final SimpleRunConfig config = new SimpleRunConfig(new String[]{"-w", "who"});
+        assertThat(status, is(1));
     }
 }

--- a/src/test/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunnerTest.java
+++ b/src/test/java/com/amazon/corretto/benchmark/heapothesys/SimpleRunnerTest.java
@@ -1,12 +1,8 @@
 package com.amazon.corretto.benchmark.heapothesys;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 public class SimpleRunnerTest {
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void DefaultRunTest() {


### PR DESCRIPTION
System Lambda allows to catch the output of exactly one statement
instead of the whole test method. This makes the test more precise. In
addition it does not depend on JUnit 4 so that it is easier to change
the testing framework later (e.g. use JUnit Jupiter).