### PR TITLE
Improve shutdown upon termination

### DIFF
--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/ObjectStore.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/ObjectStore.java
@@ -88,9 +88,8 @@ public class ObjectStore implements Runnable {
         }
     }
 
-    public long stopAndReturnSize() {
+    public synchronized long stopAndReturnSize() {
         running = false;
-
         return currentSize.get();
     }
 
@@ -98,9 +97,13 @@ public class ObjectStore implements Runnable {
         return store;
     }
 
+    private synchronized boolean amRunning() {
+        return running;
+    }
+
     @Override
     public void run() {
-        while (running) {
+        while (amRunning()) {
             try {
                 if (currentSize.get() < sizeLimit * (1D - 1D / IN_QUEUE_RATIO)) {
                     final AllocObject obj = queue.poll(1, TimeUnit.MICROSECONDS);


### PR DESCRIPTION
Multiple users reported that HyperAlloc benchmark failed to terminate at
end of requested duration.  This patch adds synchronization required to
assure visibility of shutdown request to the ObjectStore Runnable and
adds code to shutdown the java.util.concurrent.Executors threads.

https://github.com/corretto/heapothesys/issues/29
https://github.com/corretto/heapothesys/issues/36

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
