### PR TITLE
Allocation logging

### DIFF
--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/AllocObject.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/AllocObject.java
@@ -1,6 +1,7 @@
 package com.amazon.corretto.benchmark.hyperalloc;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * The representation of an allocated object with fixed size in heap. It can also have a reference
@@ -8,6 +9,8 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 class AllocObject {
     private static ObjectOverhead objectOverhead = ObjectOverhead.CompressedOops;
+
+    private static final LongAdder BytesAllocated = new LongAdder();
 
     /**
      * Set the object overhead. By default it assumes that compressedOops is enabled.
@@ -78,7 +81,25 @@ class AllocObject {
      */
     static AllocObject create(final int min, final int max, final AllocObject ref) {
         assert max >= min : "The max value must be greater than min";
-        return new AllocObject(min == max ? min : ThreadLocalRandom.current().nextInt(max - min) + min, ref);
+        int size = getRandomSize(min, max);
+        return create(size, ref);
+    }
+
+    static int getRandomSize(int min, int max) {
+        return min == max ? min : ThreadLocalRandom.current().nextInt(max - min) + min;
+    }
+
+    static AllocObject create(final int size) {
+        return create(size, null);
+    }
+
+    static AllocObject create(final int size, final AllocObject ref) {
+        BytesAllocated.add(size);
+        return new AllocObject(size, ref);
+    }
+
+    static long getBytesAllocated() {
+        return BytesAllocated.longValue();
     }
 
     /**

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
@@ -16,6 +16,7 @@ public class SimpleRunConfig {
     private int reshuffleRatio = ObjectStore.DEFAULT_RESHUFFLE_RATIO;
     private int heapSizeInMb = 1024;
     private String logFile = "output.csv";
+    private String allocationLogFile = null;
 
     /**
      * Parse input arguments from a string array.
@@ -47,6 +48,8 @@ public class SimpleRunConfig {
                 useCompressedOops = Boolean.parseBoolean(args[++i]);
             } else if (args[i].equals("-l")) {
                 logFile = args[++i];
+            } else if (args[i].equals("-b") || args[i].equals("--allocation-log")) {
+                allocationLogFile = args[++i];
             } else if (args[i].equals("-u")) {
                 i++;
             } else {
@@ -54,7 +57,7 @@ public class SimpleRunConfig {
                         "[-u run type] [-a allocRateInMb] [-h heapSizeInMb] [-s longLivedObjectsInMb] " +
                         "[-m midAgedObjectsInMb] [-d runDurationInSeconds ] [-t numOfThreads] [-n minObjectSize] " +
                         "[-x maxObjectSize] [-r pruneRatio] [-f reshuffleRatio] [-c useCompressedOops] " +
-                        "[-l outputFile]");
+                        "[-l outputFile] [-b|-allocation-log logFile");
                 System.exit(1);
             }
         }
@@ -74,11 +77,13 @@ public class SimpleRunConfig {
      * @param reshuffleRatio The reshuffle ratio.
      * @param useCompressedOops Whether compressedOops is enabled.
      * @param logFile The name of the output .csv file.
+     * @param allocationLogFile The name of the allocation log file.
      */
     public SimpleRunConfig(final long allocRateInMbPerSecond, final int heapSizeInMb, final int longLivedInMb,
                            final int midAgedInMb, final int durationInSecond, final int numOfThreads,
                            final int minObjectSize, final int maxObjectSize, final int pruneRatio,
-                           final int reshuffleRatio, final boolean useCompressedOops, final String logFile) {
+                           final int reshuffleRatio, final boolean useCompressedOops, final String logFile,
+                           final String allocationLogFile) {
         this.allocRateInMbPerSecond = allocRateInMbPerSecond;
         this.heapSizeInMb = heapSizeInMb;
         this.longLivedInMb = longLivedInMb;
@@ -91,6 +96,7 @@ public class SimpleRunConfig {
         this.reshuffleRatio = reshuffleRatio;
         this.useCompressedOops = useCompressedOops;
         this.logFile = logFile;
+        this.allocationLogFile = allocationLogFile;
     }
 
     public long getAllocRateInMbPerSecond() {
@@ -139,6 +145,10 @@ public class SimpleRunConfig {
 
     public String getLogFile() {
         return logFile;
+    }
+
+    public String  getAllocationLogFile() {
+        return allocationLogFile;
     }
 }
 

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
@@ -115,7 +115,7 @@ public class SimpleRunner extends TaskBase {
                 .collect(Collectors.toList());
     }
 
-    private class AllocationRateLogger implements Runnable {
+    private static class AllocationRateLogger implements Runnable {
 
         volatile boolean shouldRun = true;
         private final Thread allocationLoggerThread;
@@ -155,7 +155,7 @@ public class SimpleRunner extends TaskBase {
             long lastTime = System.nanoTime();
             long startTime = lastTime;
 
-            try (PrintWriter writer = new PrintWriter(config.getAllocationLogFile())) {
+            try (PrintWriter writer = new PrintWriter(allocationLogFile)) {
                 while (shouldRun) {
                     long now = System.nanoTime();
                     long timeDeltaNs = now - lastTime;
@@ -177,8 +177,11 @@ public class SimpleRunner extends TaskBase {
                     //noinspection BusyWait
                     Thread.sleep(100);
                 }
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
+            } catch (IOException ioe) {
+                System.err.println("Cannot write to allocation log: " + allocationLogFile);
+                ioe.printStackTrace(System.err);
+            } catch (InterruptedException iee) {
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
@@ -46,22 +46,22 @@ public class SimpleRunner extends TaskBase {
                 System.exit(1);
             }
 
-	    executor.shutdown();
-	    try {
-	      // All tasks should already be idle, but we'll still
-	      // allow 60 seconds for termination.
-	      if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-		executor.shutdownNow(); // Recommended protocol is overkill
-		if (!executor.awaitTermination(60, TimeUnit.SECONDS))
-		  System.err.println("Executor pool did not terminate!\n");
-	      }
-	    } catch (InterruptedException ie) {
-	      System.err.println("Unexpected exception shutting down Executor pool\n");
-	      // Recancel just to be sure
-	      executor.shutdownNow();
-	      // Preserve interrupt status
-	      Thread.currentThread().interrupt();
-	    }
+            executor.shutdown();
+            try {
+                // All tasks should already be idle, but we'll still
+                // allow 60 seconds for termination.
+                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                    executor.shutdownNow(); // Recommended protocol is overkill
+                    if (!executor.awaitTermination(60, TimeUnit.SECONDS))
+                        System.err.println("Executor pool did not terminate!\n");
+                }
+            } catch (InterruptedException ie) {
+                System.err.println("Unexpected exception shutting down Executor pool\n");
+                // Recancel just to be sure
+                executor.shutdownNow();
+                // Preserve interrupt status
+                Thread.currentThread().interrupt();
+            }
             store.stopAndReturnSize();
             printResult((config.getAllocRateInMbPerSecond() * 1024L * 1024L * config.getDurationInSecond() - sum)
                     / config.getDurationInSecond() / 1024 / 1024);
@@ -88,7 +88,7 @@ public class SimpleRunner extends TaskBase {
     }
 
     private List<Callable<Long>> createTasks(final ObjectStore store) {
-        final int queueSize = (int)(config.getMidAgedInMb() * 1024L * 1024L * 2L
+        final int queueSize = (int) (config.getMidAgedInMb() * 1024L * 1024L * 2L
                 / (config.getMaxObjectSize() + config.getMinObjectSize())
                 / config.getNumOfThreads());
 

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
@@ -30,7 +30,7 @@ class SimpleRunConfigTest {
     void ConstructorTest() {
         final SimpleRunConfig config = new SimpleRunConfig(16384L, 32768, 256,
                 32, 3000, 16, 256, 512,
-                10, 20, false, "nosuch.csv");
+                10, 20, false, "nosuch.csv", null);
 
         assertThat(config.getNumOfThreads(), is(16));
         assertThat(config.getAllocRateInMbPerSecond(), is(16384L));


### PR DESCRIPTION
*Description of changes:*
Continuously log the allocation rate to a file. It's useful to see this metric when examining other jvm performance metrics. An option to control the target file has been added and must be defined to enable this feature.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
