### PR TITLE
replace printStackTrace() to using java.util.logging

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Arraylet.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Arraylet.java
@@ -133,7 +133,7 @@ class Arraylet<BaseType> extends ExtrememObject {
     BaseType[] elements = (BaseType []) fan_out_node[at / max_length];
     return elements[at % max_length];
   }
-  
+
   final void set(int at, BaseType value) {
     if ((at < 0) || (at >= length)) {
       Exception x = new ArrayIndexOutOfBoundsException(at);
@@ -189,7 +189,6 @@ class Arraylet<BaseType> extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during first batch");
-      x.printStackTrace();
     }
 
     try {
@@ -204,7 +203,7 @@ class Arraylet<BaseType> extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during second batch");
-      x.printStackTrace();
+      Util.printException(x);
     }
 
     try {
@@ -219,7 +218,7 @@ class Arraylet<BaseType> extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during third batch");
-      x.printStackTrace();
+      Util.printException(x);
     }
   }
 }

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ArrayletOflong.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ArrayletOflong.java
@@ -137,7 +137,7 @@ class ArrayletOflong extends ExtrememObject {
     long[] elements = (long []) fan_out_node[at / max_length];
     return elements[at % max_length];
   }
-  
+
   final void set(int at, long value) {
     if ((at < 0) || (at >= length)) {
       Exception x = new ArrayIndexOutOfBoundsException(at);
@@ -195,7 +195,7 @@ class ArrayletOflong extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during first batch");
-      x.printStackTrace();
+      Util.printException(x);
     }
 
     try {
@@ -210,7 +210,7 @@ class ArrayletOflong extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during second batch");
-      x.printStackTrace();
+      Util.printException(x);
     }
 
     try {
@@ -225,7 +225,7 @@ class ArrayletOflong extends ExtrememObject {
       }
     } catch (Exception x) {
       Trace.debug("caught exception during third batch");
-      x.printStackTrace();
+      Util.printException(x);
     }
   }
 }

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Util.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Util.java
@@ -4,6 +4,8 @@
 package com.amazon.corretto.benchmark.extremem;
 
 import java.util.Collection;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
 class Util {
 
@@ -31,6 +33,8 @@ class Util {
 
   static final int InitialHashMapArraySize = 16;
 
+  static Logger logger = Logger.getGlobal();
+
   /*
    * Generic utilities
    */
@@ -44,14 +48,18 @@ class Util {
   static void fatalException(String msg, Throwable t) {
     System.err.print("Intecepted fatal exception: ");
     System.err.println(msg);
-    t.printStackTrace();
+    printException(t);
     System.exit(-1);
+  }
+
+  static void printException(Throwable t) {
+      logger.log(Level.INFO, t.getMessage(), t);
   }
 
   // Use this service, without a message, when there is a strong
   // likelihood that we are out of memory and any attempt to print
   // a message will result in exceptions, thereby circumventing the exit
-  // attempt. 
+  // attempt.
   static void severeInternalError() {
     System.exit(-1);
   }
@@ -174,7 +182,7 @@ class Util {
     log.accumulate(LifeSpan.Ephemeral, MemoryFlavor.ArrayRSB, Grow,
 		   len * element_size);
   }
-  
+
   static void abandonEphemeralRSBArray(ExtrememThread t,
 				       int len, int element_size) {
     MemoryLog garbage = t.garbageLog();
@@ -242,7 +250,7 @@ class Util {
     log.accumulate (ls, MemoryFlavor.ObjectReference, p, tree_entries * 5);
     log.accumulate (ls, MemoryFlavor.ObjectRSB, p,
 		    tree_entries * Util.SizeOfBoolean);
-  }			 
+  }
 
   static void createTreeNode(ExtrememThread t, LifeSpan ls) {
     Polarity Grow = Polarity.Expand;
@@ -315,7 +323,7 @@ class Util {
     // Account for referenced array
     garbage.accumulate(ls, MemoryFlavor.ArrayObject, Grow, 1);
     garbage.accumulate(ls, MemoryFlavor.ArrayReference, Grow, capacity);
-    
+
     tallyHashNodes(garbage, ls, Grow, size);
   }
 
@@ -345,7 +353,7 @@ class Util {
     l.accumulate(ls, MemoryFlavor.PlainObject, p, n);
     l.accumulate (ls, MemoryFlavor.ObjectReference, p, n * 3);
     l.accumulate (ls, MemoryFlavor.ObjectRSB, p, n * Util.SizeOfInt);
-    
+
   }
 
   // Usie addHashEntry and abandonHashEntry to adjust the number of
@@ -356,7 +364,7 @@ class Util {
     Polarity Grow = Polarity.Expand;
     // Identify that one node of HashMap representation has become garbage.
     // Each node consists of a key, content, and next reference fields
-    // and an int hash_code field. 
+    // and an int hash_code field.
     log.accumulate (ls, MemoryFlavor.PlainObject, Grow, 1);
     log.accumulate (ls, MemoryFlavor.ObjectReference, Grow, 3);
     log.accumulate (ls, MemoryFlavor.ObjectRSB, Grow, Util.SizeOfInt);
@@ -367,7 +375,7 @@ class Util {
     Polarity Grow = Polarity.Expand;
     // Identify that one node of HashMap representation has become garbage.
     // Each node consists of a key, content, and next reference fields
-    // and an int hash_code field. 
+    // and an int hash_code field.
     garbage.accumulate (ls, MemoryFlavor.PlainObject, Grow, 1);
     garbage.accumulate (ls, MemoryFlavor.ObjectReference, Grow, 3);
     garbage.accumulate (ls, MemoryFlavor.ObjectRSB, Grow, Util.SizeOfInt);
@@ -420,7 +428,7 @@ class Util {
   /*
    * Memory accounting utilities for HashSet
    */
-  
+
   /* Account for the HashSet representations associated with name and
    * descriptor indexes used for Product lookups.  This accounting
    * does not include memory to represent the individual Long
@@ -500,7 +508,7 @@ class Util {
   }
 
   // Discard the StringBuilder and its backing store.  Allocate string
-  // and its backing store. 
+  // and its backing store.
   static void ephemeralStringBuilderToString(ExtrememThread t,
 					     int count, int capacity) {
     MemoryLog garbage = t.garbageLog();

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/ObjectStore.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/ObjectStore.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The object store for long lived object. The objects are stored in a list of object lists. Objects from one list may
@@ -39,6 +41,8 @@ public class ObjectStore implements Runnable {
 
     private AtomicLong currentSize;
     private boolean running;
+
+    static Logger logger = Logger.getGlobal();
 
     public ObjectStore(final int sizeLimitInMb) {
         this(sizeLimitInMb, DEFAULT_PRUNE_RATIO, DEFAULT_RESHUFFLE_RATIO);
@@ -127,7 +131,7 @@ public class ObjectStore implements Runnable {
 
                 Thread.sleep(INTERVAL_IN_MS);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                logger.log(Level.SEVERE, e.getMessage(), e);
                 System.exit(1);
             }
         }

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
@@ -13,6 +13,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -28,6 +30,8 @@ public class SimpleRunner extends TaskBase {
     public SimpleRunner(SimpleRunConfig config) {
         this.config = config;
     }
+
+    static Logger logger = Logger.getGlobal();
 
     @Override
     public void start() {
@@ -58,7 +62,7 @@ public class SimpleRunner extends TaskBase {
                     r.get();
                 }
             } catch (ExecutionException ex) {
-                ex.printStackTrace();
+                logger.log(Level.SEVERE, ex.getMessage(), ex);
                 printResult(-1);
                 System.exit(1);
             }
@@ -181,7 +185,7 @@ public class SimpleRunner extends TaskBase {
                 }
             } catch (IOException ioe) {
                 System.err.println("Cannot write to allocation log: " + allocationLogFile);
-                ioe.printStackTrace(System.err);
+                logger.log(Level.SEVERE, ioe.getMessage(), ioe);
             } catch (InterruptedException iee) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/corretto/heapothesys/issues/18

*Description of changes:*

replace printStackTrace() to using java.util.logging.

i implemented to using global logger. But should I have created a new logger in this case?

https://github.com/corretto/heapothesys/compare/master...ryota0624:fix/remove_call_printStackTrace?expand=1#diff-de300636c224d4743e44e43b88e85ca9R45
