### PR TITLE
Improve format of Extremem Histogram Reporting

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Util.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Util.java
@@ -46,7 +46,7 @@ class Util {
   }
 
   static void fatalException(String msg, Throwable t) {
-    System.err.print("Intecepted fatal exception: ");
+    System.err.print("Intercepted fatal exception: ");
     System.err.println(msg);
     printException(t);
     System.exit(-1);


### PR DESCRIPTION
*Issue #, if available:*

This patch modifies the format of histogram reports in the following
ways:

1. A vertical scale reports the number of entries represented by a star
   in this row.  A star in the first row represents an accumulation of 1
   measurement, a star in second row represents additional accumulation of 2
   measurements, a star in third row represents additional accumulation of
   4 results, and so on.

2. The horizontal scale has been shifted to start with a tally of the
   number of entries corresponding to the smallest observed measurement.
   In the previous code, the horizontal scale provided lower resolution
   and sometimes began with a confusing negative time value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
