### PR TITLE
Add an option (-p) to gradually increase the allocation rate

### DIFF
--- a/HyperAlloc/README.md
+++ b/HyperAlloc/README.md
@@ -102,6 +102,10 @@ There is also an experimental "spiky" allocator that can be used to simulate app
 
 * -z < allocation smoothness factor>, default: none (this is not enabled by default) Values may range from 0.0 to 1.0 (inclusive).
 
+In order to calm the allocation rate during startup, HyperAlloc can gradually increase the allocation rate over a period
+ of time defined by the 'ramp up seconds' option. The ramp up increases from zero to the maximum following a sinusoidal curve.
+
+* -p < ramp up seconds >, default: none, the initial allocation rate is the maximum.
 ### Example
 
 We normally use [JHiccup](https://www.azul.com/jhiccup/) to measure JVM pauses. You can either download it from its [website](https://www.azul.com/jhiccup-2/), or build it from the source code in its [GitHub repo](https://github.com/giltene/jHiccup). You can also use GC logs to measure safepoint times, allocation stalls, and Garbage Collection pauses. In the example below, we run HyperAlloc for the Shenandoah collector for 10 minutes using a 16Gb/s allocation rate and with 32Gb of a 64Gb heap occupied by long-lived objects.

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
@@ -20,6 +20,7 @@ public class SimpleRunConfig {
     private String logFile = "output.csv";
     private String allocationLogFile = null;
     private Double allocationSmoothnessFactor = null;
+    private double rampUpSeconds = 0.0;
 
     /**
      * Parse input arguments from a string array.
@@ -61,6 +62,8 @@ public class SimpleRunConfig {
                 allocationLogFile = args[++i];
             } else if (args[i].equals("-u")) {
                 i++;
+            } else if (args[i].equals("-p") || args[i].equals("--ramp-up-seconds")) {
+                rampUpSeconds = Double.parseDouble(args[++i]);
             } else {
                 usage();
                 System.exit(1);
@@ -73,7 +76,8 @@ public class SimpleRunConfig {
                 "[-u run type] [-a allocRateInMb] [-h heapSizeInMb] [-s longLivedObjectsInMb] " +
                 "[-m midAgedObjectsInMb] [-d runDurationInSeconds ] [-t numOfThreads] [-n minObjectSize] " +
                 "[-x maxObjectSize] [-r pruneRatio] [-f reshuffleRatio] [-c useCompressedOops] " +
-                "[-l outputFile] [-b|-allocation-log logFile] [-z allocationSmoothness (0 to 1.0)]");
+                "[-l outputFile] [-b|-allocation-log logFile] [-z allocationSmoothness (0 to 1.0)] " +
+                "[-p rampUpSeconds ]");
     }
 
     /**
@@ -91,13 +95,14 @@ public class SimpleRunConfig {
      * @param useCompressedOops Whether compressedOops is enabled.
      * @param logFile The name of the output .csv file.
      * @param allocationLogFile The name of the allocation log file.
+     * @param rampUpSeconds Gradually increase allocation rate over this period of time.
      */
     public SimpleRunConfig(final long allocRateInMbPerSecond, final double allocSmoothnessFactor,
                            final int heapSizeInMb, final int longLivedInMb,
                            final int midAgedInMb, final int durationInSecond, final int numOfThreads,
                            final int minObjectSize, final int maxObjectSize, final int pruneRatio,
                            final int reshuffleRatio, final boolean useCompressedOops, final String logFile,
-                           final String allocationLogFile) {
+                           final String allocationLogFile, final double rampUpSeconds) {
         this.allocRateInMbPerSecond = allocRateInMbPerSecond;
         this.allocationSmoothnessFactor = allocSmoothnessFactor;
         this.heapSizeInMb = heapSizeInMb;
@@ -112,6 +117,7 @@ public class SimpleRunConfig {
         this.useCompressedOops = useCompressedOops;
         this.logFile = logFile;
         this.allocationLogFile = allocationLogFile;
+        this.rampUpSeconds = rampUpSeconds;
     }
 
     public long getAllocRateInMbPerSecond() {
@@ -168,6 +174,10 @@ public class SimpleRunConfig {
 
     public String  getAllocationLogFile() {
         return allocationLogFile;
+    }
+
+    public double getRampUpSeconds() {
+        return rampUpSeconds;
     }
 }
 

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
@@ -121,7 +121,8 @@ public class SimpleRunner extends TaskBase {
         if (config.getAllocationSmoothnessFactor() == null) {
             factory = (ignored) -> createSingle(store, allocRateMbPerThread,
                     durationInMs, config.getMinObjectSize(),
-                    config.getMaxObjectSize(), queueSize);
+                    config.getMaxObjectSize(), queueSize,
+                    config.getRampUpSeconds());
         } else {
             factory = (ignored) -> createBurstyAllocator(store, allocRateMbPerThread,
                     durationInMs, config.getAllocationSmoothnessFactor(),
@@ -145,7 +146,6 @@ public class SimpleRunner extends TaskBase {
             allocationLoggerThread = new Thread(this);
             allocationLoggerThread.setName("HyperAlloc-Allocations");
             allocationLoggerThread.setDaemon(true);
-
         }
 
         public void start() {

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/TaskBase.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/TaskBase.java
@@ -25,6 +25,8 @@ public abstract class TaskBase {
     // The maximum ratio to try make objects long lived.
     protected static final int MAX_LONG_LIVED_RATIO = 2;
 
+    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+    
     /**
      * Start all task runners.
      */
@@ -74,7 +76,7 @@ public abstract class TaskBase {
                 long wave = 0L;
                 while (wave < rate / 10) {
                     if (rampUp != null) {
-                        final double elapsedSeconds = (System.nanoTime() - start) / 1_000_000_000.0;
+                        final double elapsedSeconds = (System.nanoTime() - start) / NANOS_PER_SECOND;
                         if (elapsedSeconds < rampUpSeconds) {
                             double currentRate = rampUp.apply(elapsedSeconds);
                             throughput.adjustThrottle((long)currentRate);

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/TokenBucket.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/TokenBucket.java
@@ -15,9 +15,9 @@ public class TokenBucket {
     private static final long DEFAULT_TIME_SLICE = TimeUnit.MILLISECONDS.toNanos(10);
     private static final int DEFAULT_OVERDRAFT_RATIO = 10;
     private final long timeSlice;
-    private final long limit;
     private final long overdraftLimit;
     private final Supplier<Long> clock;
+    private long limit;
     private long current;
     private long resetAtNanoSecond;
 
@@ -96,5 +96,12 @@ public class TokenBucket {
      */
     public boolean isThrottled() {
         return clock.get() < this.resetAtNanoSecond && current <= 0;
+    }
+
+    public void adjustThrottle(final long newLimit) {
+        limit = newLimit / 100;
+        if (current > limit) {
+            current = limit;
+        }
     }
 }

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
@@ -32,7 +32,7 @@ class SimpleRunConfigTest {
     void ConstructorTest() {
         final SimpleRunConfig config = new SimpleRunConfig(16384L, 0.0, 32768, 256,
                 32, 3000, 16, 256, 512,
-                10, 20, false, "nosuch.csv", null);
+                10, 20, false, "nosuch.csv", null, 0.0);
 
         assertThat(config.getNumOfThreads(), is(16));
         assertThat(config.getAllocRateInMbPerSecond(), is(16384L));

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/TaskBaseTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/TaskBaseTest.java
@@ -16,7 +16,7 @@ class TaskBaseTest {
 
     @Test
     void ExerciseLongLivedTest() throws Exception {
-        assertThat(TaskBase.createSingle(new ObjectStore(10), 10, 5000, 8192, 65535, 100).call(),
+        assertThat(TaskBase.createSingle(new ObjectStore(10), 10, 5000, 8192, 65535, 100, 0.0).call(),
                 lessThanOrEqualTo(0L));
     }
 }


### PR DESCRIPTION
Add an option to increase the allocation rate (following a sinusoidal curve) from zero to the maximum over the given time period (in seconds).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
