### PR TITLE
Change typo from 'HyperaAlloc.jar' to 'HyperAlloc.jar' in README.md

### DIFF
--- a/HyperAlloc/README.md
+++ b/HyperAlloc/README.md
@@ -38,7 +38,7 @@ If you would like to report a potential security issue in this project, please d
 
 Invocation with the minimum recommended set of HyperAlloc parameters and a typical jHiccup configuration:
 ```
-java -Xmx<bytes> -Xms<bytes> <GC options> <other JVM options> -Xloggc:<GC log file> -javaagent:<jHiccup directory>/jHiccup.jar='-a -d 0 -i 1000 -l <jHiccup log file>' -jar <HyperAlloc directory>/HyperaAlloc-1.0.jar -a <MB> -h <MB> -d <seconds> -c <true/false> -l <CVS output file>
+java -Xmx<bytes> -Xms<bytes> <GC options> <other JVM options> -Xloggc:<GC log file> -javaagent:<jHiccup directory>/jHiccup.jar='-a -d 0 -i 1000 -l <jHiccup log file>' -jar <HyperAlloc directory>/HyperAlloc-1.0.jar -a <MB> -h <MB> -d <seconds> -c <true/false> -l <CVS output file>
 ```
 
 ### Build


### PR DESCRIPTION
*Issue #, if available:*

There is a typo in `README.md`. It says the jar name is `HyperaAlloc.jar` while it should be `HyperAlloc.jar`. 

It is not really a big issue, but the typo is inside the copy/paste usage example and can lead to some frustration if you do not carefully check all characters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
