### PR TITLE
Deprecate initialization delay

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Arraylet.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Arraylet.java
@@ -269,7 +269,7 @@ class Arraylet<BaseType> extends ExtrememObject {
       Trace.debug("Testing Arraylet with max size 4");
       a = new Arraylet<Long>(t, LifeSpan.Ephemeral, 4, 56);
       for (int i = 0; i < 56; i++)
-        a.set(i, new Long(-10 * i));
+        a.set(i, Long.valueOf(-10 * i));
       for (int i = 55; i >= 0; i--) {
         Long l = a.get(i);
         String s1 = Integer.toString(i);
@@ -284,7 +284,7 @@ class Arraylet<BaseType> extends ExtrememObject {
       Trace.debug("Testing Arraylet with max size 7");
       a = new Arraylet<Long>(t, LifeSpan.Ephemeral, 7, 61);
       for (int i = 0; i < 61; i++)
-        a.set(i, new Long(-10 * i));
+        a.set(i, Long.valueOf(-10 * i));
       for (int i = 60; i >= 0; i--) {
         Long l = a.get(i);
         String s1 = Integer.toString(i);
@@ -300,7 +300,7 @@ class Arraylet<BaseType> extends ExtrememObject {
       Trace.debug("Testing Arraylet with max size 0");
       a = new Arraylet<Long>(t, LifeSpan.Ephemeral, 0, 61);
       for (int i = 0; i < 61; i++)
-        a.set(i, new Long(-10 * i));
+        a.set(i, Long.valueOf(-10 * i));
       for (int i = 60; i >= 0; i--) {
         Long l = a.get(i);
         String s1 = Integer.toString(i);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -25,8 +25,7 @@ public class Bootstrap extends ExtrememThread {
       
     MemoryLog memory = memoryLog();
     MemoryLog garbage = garbageLog();
-    MemoryLog all_threads_accumulator = (
-      new MemoryLog(LifeSpan.NearlyForever));
+    MemoryLog all_threads_accumulator = new MemoryLog(LifeSpan.NearlyForever);
     all_threads_accumulator.memoryFootprint(this);
       
     Trace.msg(1, "@ ",
@@ -148,35 +147,67 @@ public class Bootstrap extends ExtrememThread {
       Trace.msg(3, "Server stagger set to: ", server_stagger.toString(this));
     }
       
-    // In addition to config.InitializationDelay(), reserve 1 second for
-    // variable costs of initializing every 2000 threads.  
-    int start_delay_milliseconds = (
-      (config.CustomerThreads() + config.ServerThreads()) / 2);
+    Trace.msg(2, "starting up CustomerThreads: ", Integer.toString(config.CustomerThreads()));
       
-    RelativeTime start_delay = (config.InitializationDelay().
-                                addMillis(this, start_delay_milliseconds));
+    // Initialize and startup all of the threads as specified in
+    // config.
+    customer_threads = new CustomerThread[config.CustomerThreads()];
+    Util.referenceArray(this, LifeSpan.NearlyForever, config.CustomerThreads());
       
-    String s = start_delay.toString(this);
-    Trace.msg(3, "");
-    Trace.msg(3, "Simulation starts in ", s);
-    Util.abandonEphemeralString(this, s);
+    int bq_no = config.BrowsingHistoryQueueCount() - 1;
+    int sq_no = config.SalesTransactionQueueCount() - 1;
+    for (int i = 0; i < config.CustomerThreads(); i++) {
+      customer_threads[i] = new CustomerThread(config, randomLong(), i, all_products, all_customers, browsing_queues[bq_no],
+                                               sales_queues[sq_no], customer_accumulator, customer_alloc_accumulator,
+                                               customer_garbage_accumulator);
+      if (bq_no-- == 0) {
+        bq_no = config.BrowsingHistoryQueueCount() - 1;
+      }
+      if (sq_no-- == 0) {
+        sq_no = config.SalesTransactionQueueCount() - 1;
+      }
+    }
+    if (customer_stagger != null) {
+      customer_stagger.garbageFootprint(this);
+    }
+    Trace.msg(2, "starting up ServerThreads: ",
+              Integer.toString(config.ServerThreads()));
       
+    server_threads = new ServerThread[config.ServerThreads()];
+    Util.referenceArray(this, LifeSpan.NearlyForever, config.ServerThreads());
+      
+    bq_no = config.BrowsingHistoryQueueCount() - 1;
+    sq_no = config.SalesTransactionQueueCount() - 1;
+    for (int i = 0; i < config.ServerThreads(); i++) {
+      server_threads[i] = new ServerThread(config, randomLong(), i, all_products, all_customers, browsing_queues[bq_no],
+                                           sales_queues[sq_no], server_accumulator, server_alloc_accumulator,
+                                           server_garbage_accumulator);
+      if (bq_no-- == 0)
+        bq_no = config.BrowsingHistoryQueueCount() - 1;
+      if (sq_no-- == 0)
+        sq_no = config.SalesTransactionQueueCount() - 1;
+    }
+    
+    if (config.PhasedUpdates()) {
+      update_thread = new UpdateThread(config, randomLong(), all_products, all_customers);
+    } else {
+      update_thread = null;
+    }
+  
     AbsoluteTime now = AbsoluteTime.now(this);
-    AbsoluteTime start_time = now.addRelative(this, start_delay);
-    start_delay.garbageFootprint(this);
-    start_delay = null;
-    now.garbageFootprint(this);
-    now = null;
-    AbsoluteTime end_time = (
-      start_time.addRelative(this, config.SimulationDuration()));
+
+    // Add 2 ms to conservatively approximate the time required to establish start times and start() each thread
+    AbsoluteTime start_time = now.addMillis(this, 2 * (config.CustomerThreads() + config.ServerThreads()));
+    AbsoluteTime end_time =  start_time.addRelative(this, config.SimulationDuration());
+
+    start_time.garbageFootprint(this);
+    start_time = null;
     end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
-      
-    AbsoluteTime staggered_customer_replacement = (
-      new AbsoluteTime(this, start_time));
-      
-    AbsoluteTime staggered_product_replacement = (
-      new AbsoluteTime(this, start_time));
-      
+
+    AbsoluteTime staggered_customer_replacement = new AbsoluteTime(this, start_time);
+    AbsoluteTime staggered_product_replacement = new AbsoluteTime(this, start_time);
+
+    String s;
     if (config.ReportCSV()) {
       s = Long.toString(start_time.microseconds());
       Util.ephemeralString(this, s.length());
@@ -200,73 +231,27 @@ public class Bootstrap extends ExtrememThread {
     Trace.msg(2, "End simulation time: ", s);
     Trace.msg(2, "");
     Util.abandonEphemeralString(this, s);
-      
-    Trace.msg(2, "starting up CustomerThreads: ",
-              Integer.toString(config.CustomerThreads()));
-      
-    // Initialize and startup all of the threads as specified in
-    // config.
-    customer_threads = new CustomerThread[config.CustomerThreads()];
-    Util.referenceArray(this, LifeSpan.NearlyForever,
-                        config.CustomerThreads());
-      
+
+    // startup the customer threads
     AbsoluteTime staggered_start = start_time.addMinutes(this, 0);
-    int bq_no = config.BrowsingHistoryQueueCount() - 1;
-    int sq_no = config.SalesTransactionQueueCount() - 1;
     for (int i = 0; i < config.CustomerThreads(); i++) {
-      customer_threads[i] = (
-        new CustomerThread(config, randomLong(), i, all_products,
-                           all_customers, browsing_queues[bq_no],
-                           sales_queues[sq_no], customer_accumulator,
-                           customer_alloc_accumulator,
-                           customer_garbage_accumulator, staggered_start,
-                           end_time));
-      if (bq_no-- == 0)
-        bq_no = config.BrowsingHistoryQueueCount() - 1;
-      if (sq_no-- == 0)
-        sq_no = config.SalesTransactionQueueCount() - 1;
+      customer_threads[i].setStartAndStop(staggered_start, end_time);
       staggered_start.garbageFootprint(this);
-      staggered_start = staggered_start.addRelative(this, customer_stagger);
       customer_threads[i].start(); // will wait for first release
+      staggered_start = staggered_start.addRelative(this, customer_stagger);
     }
-    staggered_start.garbageFootprint(this);
-    if (customer_stagger != null)
-      customer_stagger.garbageFootprint(this);
-      
-    Trace.msg(2, "starting up ServerThreads: ",
-              Integer.toString(config.ServerThreads()));
-      
-    server_threads = new ServerThread[config.ServerThreads()];
-    Util.referenceArray(this,
-                        LifeSpan.NearlyForever, config.ServerThreads());
-      
+
+    // startup the server threads
     staggered_start = start_time.addMinutes(this, 0);
-      
-    bq_no = config.BrowsingHistoryQueueCount() - 1;
-    sq_no = config.SalesTransactionQueueCount() - 1;
     for (int i = 0; i < config.ServerThreads(); i++) {
-      server_threads[i] = (
-        new ServerThread(config,
-                         randomLong(), i, all_products, all_customers,
-                         browsing_queues[bq_no], sales_queues[sq_no],
-                         server_accumulator, server_alloc_accumulator,
-                         server_garbage_accumulator, staggered_start,
-                         staggered_customer_replacement,
-                         staggered_product_replacement, end_time));
-      if (bq_no-- == 0)
-        bq_no = config.BrowsingHistoryQueueCount() - 1;
-      if (sq_no-- == 0)
-        sq_no = config.SalesTransactionQueueCount() - 1;
+      server_threads[i].setStartsAndStop(staggered_start, staggered_customer_replacement, staggered_product_replacement,
+                                         end_time);
       staggered_start.garbageFootprint(this);
       staggered_start = staggered_start.addRelative(this, server_stagger);
       staggered_customer_replacement.garbageFootprint(this);
-      staggered_customer_replacement = (
-        staggered_customer_replacement
-        .addRelative(this, customer_replacement_stagger));
+      staggered_customer_replacement = staggered_customer_replacement.addRelative(this, customer_replacement_stagger);
       staggered_product_replacement.garbageFootprint(this);
-      staggered_product_replacement = (
-        staggered_product_replacement
-        .addRelative(this, product_replacement_stagger));
+      staggered_product_replacement = staggered_product_replacement.addRelative(this, product_replacement_stagger);
       server_threads[i].start(); // will wait for first release
     }
     staggered_start.garbageFootprint(this);
@@ -277,7 +262,7 @@ public class Bootstrap extends ExtrememThread {
       
     staggered_product_replacement.garbageFootprint(this);
     staggered_product_replacement = null;
-      
+
     if (server_stagger != null)
       server_stagger.garbageFootprint(this);
       
@@ -288,17 +273,15 @@ public class Bootstrap extends ExtrememThread {
     if (product_replacement_stagger != null)
       product_replacement_stagger.garbageFootprint(this);
     product_replacement_stagger = null;
-    
+
     if (config.PhasedUpdates()) {
       staggered_start = start_time.addRelative(this, config.PhasedUpdateInterval());
-      update_thread = new UpdateThread(config, randomLong(), all_products, all_customers, staggered_start, end_time);
+      update_thread.setStartAndStop(staggered_start, end_time);
       update_thread.start();    // will wait for first release
       staggered_start.garbageFootprint(this);
       staggered_start = null;
-    } else {
-      update_thread = null;
     }
-  
+
     now = AbsoluteTime.now(this);
     if (config.ReportCSV()) {
       s = Long.toString(now.microseconds());
@@ -312,9 +295,8 @@ public class Bootstrap extends ExtrememThread {
     Util.abandonEphemeralString(this, s);
 
     if (now.compare(start_time) > 0) {
-      Configuration.usage("Initialization must complete before start."
-                          + "  Increase InitializationDelay.");
-      // Does not return.
+      Report.output("Warning!  Consumed more than 2 ms to start each thread.");
+      // If you see this message, we need to tweak initialization delays in this source code.
     }
     start_time.garbageFootprint(this);
     start_time = null;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -196,13 +196,9 @@ public class Bootstrap extends ExtrememThread {
   
     AbsoluteTime now = AbsoluteTime.now(this);
 
-    // Add 2 ms to conservatively approximate the time required to establish start times and start() each thread
-    AbsoluteTime start_time = now.addMillis(this, 2 * (config.CustomerThreads() + config.ServerThreads()));
+    // Add 4 ms to conservatively approximate the time required to establish start times and start() each thread
+    AbsoluteTime start_time = now.addMillis(this, 4 * (config.CustomerThreads() + config.ServerThreads()));
     AbsoluteTime end_time =  start_time.addRelative(this, config.SimulationDuration());
-
-    start_time.garbageFootprint(this);
-    start_time = null;
-    end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
 
     AbsoluteTime staggered_customer_replacement = new AbsoluteTime(this, start_time);
     AbsoluteTime staggered_product_replacement = new AbsoluteTime(this, start_time);
@@ -254,6 +250,7 @@ public class Bootstrap extends ExtrememThread {
       staggered_product_replacement = staggered_product_replacement.addRelative(this, product_replacement_stagger);
       server_threads[i].start(); // will wait for first release
     }
+
     staggered_start.garbageFootprint(this);
     staggered_start = null;
 
@@ -295,12 +292,15 @@ public class Bootstrap extends ExtrememThread {
     Util.abandonEphemeralString(this, s);
 
     if (now.compare(start_time) > 0) {
-      Report.output("Warning!  Consumed more than 2 ms to start each thread.");
-      // If you see this message, we need to tweak initialization delays in this source code.
+      Report.output("Warning!  Consumed more than 4 ms to start each thread.");
+      s = start_time.toString(this);
+      Report.output(" Planned to start at: ", s);
+      s = now.toString(this);
+      Report.output("Actually starting at: ", s);
     }
     start_time.garbageFootprint(this);
     start_time = null;
-      
+    end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
     now.garbageFootprint(this);
     now = null;
       

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -78,7 +78,6 @@ class Configuration {
 
   static final int DefaultPhasedUpdateIntervalSeconds = 60;
 
-  static final long DefaultInitializationDelayMillis = 50;
   static final long DefaultDurationMinutes = 10;
 
   /*
@@ -107,7 +106,6 @@ class Configuration {
   private String DictionaryFile;
   private Words dictionary;
 
-  private RelativeTime InitializationDelay;
   private RelativeTime SimulationDuration;
 
   private RelativeTime CustomerPeriod;
@@ -183,11 +181,11 @@ class Configuration {
                    2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
     // Account for 11 reference fields: args, dictionary,
-    // DictionaryFile, InitializationDelay, SimulationDuration,
+    // DictionaryFile, SimulationDuration,
     // CustomerPeriod, CustomerThinkTime, ServerPeriod, BrowsingExpiration,
     // CustomerReplacementPeriod, ProductReplacementPeriod.
     log.accumulate(LifeSpan.NearlyForever,
-                   MemoryFlavor.ObjectReference, Polarity.Expand, 11);
+                   MemoryFlavor.ObjectReference, Polarity.Expand, 10);
 
     ResponseTimeMeasurements = DefaultResponseTimeMeasurements;
     ReportIndividualThreads = DefaultReportIndividualThreads;
@@ -210,11 +208,6 @@ class Configuration {
 
     SimulationDuration = new RelativeTime(t, DefaultDurationMinutes * 60, 0);
     SimulationDuration.changeLifeSpan(t, LifeSpan.NearlyForever);
-
-    InitializationDelay = (
-      new RelativeTime(t, DefaultInitializationDelayMillis / 1000, (int)
-                       (DefaultInitializationDelayMillis % 1000) * 1000000));
-    InitializationDelay.changeLifeSpan(t, LifeSpan.NearlyForever);
 
     RelativeTime rt = new RelativeTime(t);
     CustomerPeriod = rt.addMinutes(t, DefaultCustomerPeriodMinutes);
@@ -552,9 +545,9 @@ class Configuration {
         u *= 60;                // convert minutes to seconds
       case 's':
         u *= 1000;              // convert seconds to ms
-      case '@':
+      case '@':                 // '@' represents ms
         break;
-      case '$':
+      case '$':                 // '$' represents no time unit specified
       default:
         usage("Time suffix must be ms, s, m, h, or d");
     }
@@ -596,9 +589,7 @@ class Configuration {
         }
       case 4:
         if (keyword.equals("InitializationDelay")) {
-          InitializationDelay.garbageFootprint(t);
-          InitializationDelay = new RelativeTime(t, secs, nanos);
-          InitializationDelay.changeLifeSpan(t, LifeSpan.NearlyForever);
+          Report.output("Warning.  InitializationDelay is deprecated and ignored");
           break;
         }
       case 5:
@@ -827,10 +818,6 @@ class Configuration {
     return SimulationDuration;
   }
 
-  RelativeTime InitializationDelay() {
-    return InitializationDelay;
-  }
-
   RelativeTime CustomerPeriod() {
     return CustomerPeriod;
   }
@@ -926,12 +913,6 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("RandomSeed,", s);
-    Util.abandonEphemeralString(t, l);
-
-    s = Long.toString(InitializationDelay.microseconds());
-    l = s.length();
-    Util.ephemeralString(t, l);
-    Report.output("InitializationDelay,", s);
     Util.abandonEphemeralString(t, l);
 
     s = Long.toString(SimulationDuration.microseconds());
@@ -1143,11 +1124,6 @@ class Configuration {
     Report.output("    Seed for random number generation (RandomSeed): ", s);
     Util.abandonEphemeralString(t, l);
 
-    s = InitializationDelay.toString(t);
-    l = s.length();
-    Report.output("               Startup Pause (InitializationDelay): ", s);
-    Util.abandonEphemeralString(t, l);
-
     s = SimulationDuration.toString(t);
     l = s.length();
     Report.output("                     Duration (SimulationDuration): ", s);
@@ -1333,16 +1309,15 @@ class Configuration {
                        Grow, 17 * Util.SizeOfInt +
                        2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
-    // Account for 11 reference fields: args, dictionary, DictionaryFile
-    // InitializationDelay, SimulationDuration, CustomerPeriod,
+    // Account for 10 reference fields: args, dictionary, DictionaryFile
+    // SimulationDuration, CustomerPeriod,
     // CustomerThinkTime, ServerPeriod, BrowsingExpiration,
     // CustomerReplacementPeriod, ProductReplacementPeriod 
     garbage.accumulate(LifeSpan.NearlyForever,
-                       MemoryFlavor.ObjectReference, Polarity.Expand, 11);
+                       MemoryFlavor.ObjectReference, Polarity.Expand, 10);
 
     Util.tallyString(t.garbageLog(), LifeSpan.NearlyForever,
                      Polarity.Expand, DictionaryFile.length());
-    InitializationDelay.garbageFootprint(t);
     SimulationDuration.garbageFootprint(t);
     CustomerPeriod.garbageFootprint(t);
     CustomerThinkTime.garbageFootprint(t);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -180,7 +180,7 @@ class Configuration {
                    Polarity.Expand, 17 * Util.SizeOfInt +
                    2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
-    // Account for 11 reference fields: args, dictionary,
+    // Account for 10 reference fields: args, dictionary,
     // DictionaryFile, SimulationDuration,
     // CustomerPeriod, CustomerThinkTime, ServerPeriod, BrowsingExpiration,
     // CustomerReplacementPeriod, ProductReplacementPeriod.

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -11,7 +11,7 @@ class CustomerThread extends ExtrememThread {
   private final Customers all_customers;
   private final Products all_products;
   private AbsoluteTime next_release_time;
-  private final AbsoluteTime end_simulation_time;
+  private AbsoluteTime end_simulation_time;
 
   private final BrowsingHistoryQueue browsing_queue;
   private final SalesTransactionQueue sales_queue;
@@ -39,8 +39,7 @@ class CustomerThread extends ExtrememThread {
                   SalesTransactionQueue sales_queue,
                   CustomerLogAccumulator accumulator,
                   MemoryLog alloc_accumulator,
-                  MemoryLog garbage_accumulator,
-                  AbsoluteTime first_release, AbsoluteTime end_simulation) {
+                  MemoryLog garbage_accumulator) {
     super (config, random_seed);
     MemoryLog log = this.memoryLog();
     MemoryLog garbage = this.garbageLog();
@@ -59,11 +58,6 @@ class CustomerThread extends ExtrememThread {
     this.browsing_queue = browsing_queue;
     this.sales_queue = sales_queue;
     
-    // We'll count the period of CustomerThread activities as
-    // Ephemeral: next_release is discarded and reallocated every period.
-    next_release_time = new AbsoluteTime(this, first_release);
-    end_simulation_time = end_simulation;
-    
     this.accumulator = accumulator;
     this.alloc_accumulator = alloc_accumulator;
     this.garbage_accumulator = garbage_accumulator;
@@ -78,6 +72,13 @@ class CustomerThread extends ExtrememThread {
     
     // Account for object referenced by history.
     history.tallyMemory(log, ls, Polarity.Expand);
+  }
+
+  public void setStartAndStop(AbsoluteTime start, AbsoluteTime stop) {
+    // We'll count the period of CustomerThread activities as
+    // Ephemeral: next_release is discarded and reallocated every period.
+    this.next_release_time = new AbsoluteTime(this, start);
+    this.end_simulation_time = stop;
   }
 
   public void runExtreme() {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
@@ -13,8 +13,9 @@ class UpdateThread extends ExtrememThread {
   private final Configuration config;
   private final Products all_products;
   private final Customers all_customers;
+
   private AbsoluteTime next_release_time;
-  private final AbsoluteTime end_simulation_time;
+  private AbsoluteTime end_simulation_time;
 
   private long customers_rebuild_count = 0;
   private long replaced_customers_min = 0;
@@ -35,8 +36,7 @@ class UpdateThread extends ExtrememThread {
   // private final MemoryLog alloc_accumulator;
   // private final MemoryLog garbage_accumulator;
 
-  UpdateThread(Configuration config, long random_seed, Products all_products, Customers all_customers,
-               AbsoluteTime first_release, AbsoluteTime end_simulation) {
+  UpdateThread(Configuration config, long random_seed, Products all_products, Customers all_customers) {
       super (config, random_seed);
       final Polarity Grow = Polarity.Expand;
       final MemoryLog log = this.memoryLog();
@@ -50,12 +50,6 @@ class UpdateThread extends ExtrememThread {
 
       this.all_customers = all_customers;
       this.all_products = all_products;
-
-      // Replaced every period, typically less than 2 minutes for ServerThread.
-      this.next_release_time = new AbsoluteTime(this, first_release);
-      this.next_release_time.changeLifeSpan(this, LifeSpan.TransientShort);
-
-      this.end_simulation_time = end_simulation;
 
       // this.accumulator = accumulator;
       // this.alloc_accumulator = alloc_accumulator;
@@ -72,7 +66,16 @@ class UpdateThread extends ExtrememThread {
       // log.accumulate(LifeSpan.NearlyForever,
       //                MemoryFlavor.ObjectRSB, Grow, Util.SizeOfInt);
   }
-  
+
+  public void setStartAndStop(AbsoluteTime first_release, AbsoluteTime end_simulation) {
+    // Replaced every period, typically less than 2 minutes for ServerThread.
+    this.next_release_time = new AbsoluteTime(this, first_release);
+    this.next_release_time.changeLifeSpan(this, LifeSpan.TransientShort);
+
+    this.end_simulation_time = end_simulation;
+  }
+
+
   public void runExtreme() {
     long customers_rebuild_count = 0;
     long replaced_customers_min = 0;


### PR DESCRIPTION
Automatically calculate the initialization delay rather than requiring users to guess and specify.  The original InitializationDelay command-line argument is still supported for compatibility with existing scripts, but the value is ignored.

Additionally, fix up a few comments and remove dependencies on deprecated new Long() constructor.
