### PR TITLE
Remove some System.exit usages

### DIFF
--- a/HyperAlloc/pom.xml
+++ b/HyperAlloc/pom.xml
@@ -65,11 +65,6 @@
                 <version>5.6.2</version>
             </dependency>
             <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-lambda</artifactId>
-                <version>1.0.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>2.2</version>
@@ -86,10 +81,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/HyperAlloc.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/HyperAlloc.java
@@ -3,29 +3,15 @@
 package com.amazon.corretto.benchmark.hyperalloc;
 
 public final class HyperAlloc {
-    private static final String DEFAULT_RUN_TYPE = "simple";
-
     private HyperAlloc() {}
 
     public static void main(String[] args) {
-
-        switch (findRunType(args)) {
-            case "simple" :
-                new SimpleRunner(new SimpleRunConfig(args)).start();
-                break;
-            default:
-                System.out.println("Current supported run type (-u): simple.");
-                System.exit(1);
+        try {
+            new SimpleRunner(new SimpleRunConfig(args)).start();
+        } catch (IllegalArgumentException e) {
+            SimpleRunConfig.usage();
+            System.exit(1);
         }
-    }
-
-    private static String findRunType(final String[] args) {
-        for (int i = 0; i < args.length - 1; i++) {
-            if (args[i].equals("-u")) {
-                return args[i + 1];
-            }
-        }
-        return DEFAULT_RUN_TYPE;
     }
 }
 

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
@@ -17,10 +17,10 @@ public class SimpleRunConfig {
     private int numOfThreads = 4;
     private int minObjectSize = 128;
     private int maxObjectSize = 1024;
-    private boolean useCompressedOops;
+    private final boolean useCompressedOops;
     private int pruneRatio = ObjectStore.DEFAULT_PRUNE_RATIO;
     private int reshuffleRatio = ObjectStore.DEFAULT_RESHUFFLE_RATIO;
-    private int heapSizeInMb = (int)(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / 1048576L);
+    private final int heapSizeInMb = (int) (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / 1048576L);
     private String logFile = "output.csv";
     private String allocationLogFile = null;
     private Double allocationSmoothnessFactor = null;
@@ -33,6 +33,7 @@ public class SimpleRunConfig {
 
     /**
      * Parse input arguments from a string array.
+     *
      * @param args The string array of the arguments.
      */
     public SimpleRunConfig(final String[] args) {
@@ -65,27 +66,26 @@ public class SimpleRunConfig {
             } else if (args[i].equals("-z")) {
                 allocationSmoothnessFactor = Double.parseDouble(args[++i]);
                 if (allocationSmoothnessFactor < 0 || allocationSmoothnessFactor > 1.0) {
-                    usage();
-                    System.exit(1);
+                    throw new IllegalArgumentException("-z must be between 0.0 and 1.0");
                 }
             } else if (args[i].equals("-l")) {
                 logFile = args[++i];
             } else if (args[i].equals("-b") || args[i].equals("--allocation-log")) {
                 allocationLogFile = args[++i];
             } else if (args[i].equals("-u")) {
+                System.out.println("Use of -u has been deprecated");
                 i++;
             } else if (args[i].equals("-p") || args[i].equals("--ramp-up-seconds")) {
                 rampUpSeconds = Double.parseDouble(args[++i]);
             } else {
-                usage();
-                System.exit(1);
+                throw new IllegalArgumentException("Unknown argument: " + args[i]);
             }
         }
     }
 
-    private void usage() {
+    public static void usage() {
         System.out.println("Usage: java -jar HyperAlloc.jar " +
-                "[-u run type] [-a allocRateInMb] [-s longLivedObjectsInMb] " +
+                "[-a allocRateInMb] [-s longLivedObjectsInMb] " +
                 "[-m midAgedObjectsInMb] [-d runDurationInSeconds ] [-t numOfThreads] [-n minObjectSize] " +
                 "[-x maxObjectSize] [-r pruneRatio] [-f reshuffleRatio] " +
                 "[-l outputFile] [-b|-allocation-log logFile] [-z allocationSmoothness (0 to 1.0)] " +
@@ -94,26 +94,24 @@ public class SimpleRunConfig {
 
     /**
      * Creating a simple config from parameters.
+     *
      * @param allocRateInMbPerSecond Allocation rate in Mb per second.
-     * @param heapSizeInMb Heap size (-Xmx) in Mb.
-     * @param longLivedInMb The size of long-lived objects in Mb.
-     * @param midAgedInMb The size of mid-aged objects in Mb.
-     * @param durationInSecond The run duration in seconds.
-     * @param numOfThreads The number of runner threads.
-     * @param minObjectSize The minimum object size in byte.
-     * @param maxObjectSize The maximum object size in byte.
-     * @param pruneRatio The prune ratio per minute.
-     * @param reshuffleRatio The reshuffle ratio.
-     * @param useCompressedOops Whether compressedOops is enabled.
-     * @param logFile The name of the output .csv file.
-     * @param allocationLogFile The name of the allocation log file.
-     * @param rampUpSeconds Gradually increase allocation rate over this period of time.
+     * @param longLivedInMb          The size of long-lived objects in Mb.
+     * @param midAgedInMb            The size of mid-aged objects in Mb.
+     * @param durationInSecond       The run duration in seconds.
+     * @param numOfThreads           The number of runner threads.
+     * @param minObjectSize          The minimum object size in byte.
+     * @param maxObjectSize          The maximum object size in byte.
+     * @param pruneRatio             The prune ratio per minute.
+     * @param reshuffleRatio         The reshuffle ratio.
+     * @param logFile                The name of the output .csv file.
+     * @param allocationLogFile      The name of the allocation log file.
+     * @param rampUpSeconds          Gradually increase allocation rate over this period of time.
      */
     public SimpleRunConfig(final long allocRateInMbPerSecond, final double allocSmoothnessFactor,
-                           final int heapSizeInMb, final int longLivedInMb,
-                           final int midAgedInMb, final int durationInSecond, final int numOfThreads,
+                           final int longLivedInMb, final int midAgedInMb, final int durationInSecond, final int numOfThreads,
                            final int minObjectSize, final int maxObjectSize, final int pruneRatio,
-                           final int reshuffleRatio, final boolean useCompressedOops, final String logFile,
+                           final int reshuffleRatio, final String logFile,
                            final String allocationLogFile, final double rampUpSeconds) {
         this.allocRateInMbPerSecond = allocRateInMbPerSecond;
         this.allocationSmoothnessFactor = allocSmoothnessFactor;
@@ -182,7 +180,7 @@ public class SimpleRunConfig {
         return allocationSmoothnessFactor;
     }
 
-    public String  getAllocationLogFile() {
+    public String getAllocationLogFile() {
         return allocationLogFile;
     }
 

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/HyperAllocTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/HyperAllocTest.java
@@ -4,26 +4,9 @@ package com.amazon.corretto.benchmark.hyperalloc;
 
 import org.junit.jupiter.api.Test;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
 class HyperAllocTest {
-
-    @Test
-    void SimpleRunTest() {
-        HyperAlloc.main(new String[]{"-u", "simple", "-d", "5"});
-    }
-
     @Test
     void DefaultRunTypeTest() {
         HyperAlloc.main(new String[]{"-d", "5"});
-    }
-
-    @Test
-    void UnknownRunTypeTest() throws Exception {
-        int status = catchSystemExit(
-                () -> HyperAlloc.main(new String[]{"-u", "unknown", "-a", "5"}));
-        assertThat(status, is(1));
     }
 }

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfigTest.java
@@ -3,15 +3,13 @@
 package com.amazon.corretto.benchmark.hyperalloc;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.management.ManagementFactory;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SimpleRunConfigTest {
@@ -45,9 +43,9 @@ class SimpleRunConfigTest {
 
     @Test
     void ConstructorTest() {
-        final SimpleRunConfig config = new SimpleRunConfig(16384L, 0.0, 32768, 256,
+        final SimpleRunConfig config = new SimpleRunConfig(16384L, 0.0, 256,
                 32, 3000, 16, 256, 512,
-                10, 20, false, "nosuch.csv", null, 0.0);
+                10, 20, "nosuch.csv", null, 0.0);
 
         assertThat(config.getNumOfThreads(), is(16));
         assertThat(config.getAllocRateInMbPerSecond(), is(16384L));
@@ -84,11 +82,12 @@ class SimpleRunConfigTest {
     }
 
     @Test
-    void UnknownParameterShouldExitTest() throws Exception {
-        int status = catchSystemExit(
-                () -> new SimpleRunConfig(new String[]{"-w", "who"}));
-        assertThat(status, is(1));
+    void UnknownParameterShouldExitTest() {
+        try {
+            new SimpleRunConfig(new String[]{"-w", "who"});
+            fail("Expected IllegalArgumentException here");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("Unknown"));
+        }
     }
-
-    class MySecurityManager extends SecurityManager {}
 }


### PR DESCRIPTION
With the removal of the security manager from JDK24, it is no longer feasible for the unit tests to intercept `System.exit` calls. Better to just remove these calls and throw `IllegalArgumentException` instead.

https://github.com/corretto/heapothesys/issues/77
