### PR TITLE
Use JOL to determine AllocObject overhead and minimum size

### DIFF
--- a/HyperAlloc/pom.xml
+++ b/HyperAlloc/pom.xml
@@ -79,10 +79,19 @@
                 <artifactId>mockito-core</artifactId>
                 <version>3.3.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.jol</groupId>
+                <artifactId>jol-core</artifactId>
+                <version>0.17</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -392,21 +401,29 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>false</addClasspath>
-                            <mainClass>com.amazon.corretto.benchmark.hyperalloc.HyperAlloc</mainClass>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                        <manifestEntries>
-                            <Premain-Class>com.amazon.corretto.benchmark.hyperalloc.HyperAlloc</Premain-Class>
-                            <Agent-Class>com.amazon.corretto.benchmark.hyperalloc.HyperAlloc</Agent-Class>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>hyper-alloc</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>HyperAlloc</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>org.openjdk.jol.vm.InstrumentationSupport</Premain-Class>
+                                        <Launcher-Agent-Class>org.openjdk.jol.vm.InstrumentationSupport$Installer</Launcher-Agent-Class>
+                                    </manifestEntries>
+                                    <mainClass>com.amazon.corretto.benchmark.hyperalloc.HyperAlloc</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/AllocObject.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/AllocObject.java
@@ -3,6 +3,7 @@
 package com.amazon.corretto.benchmark.hyperalloc;
 
 import org.openjdk.jol.info.ClassLayout;
+import org.openjdk.jol.info.GraphLayout;
 
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.LongAdder;
@@ -19,9 +20,12 @@ class AllocObject {
     private AllocObject next;
     private final byte[] data;
 
+    AllocObject(final int size) {
+        this.data = new byte[size];
+        this.next = null;
+    }
+
     AllocObject(final int size, final AllocObject ref) {
-        assert size >= objectOverhead.getOverhead()
-                : "The object size cannot be smaller than the overhead(" + objectOverhead + ").";
         this.data = new byte[size - objectOverhead.getOverhead()];
         this.next = ref;
     }
@@ -90,6 +94,8 @@ class AllocObject {
     }
 
     static AllocObject create(final int size, final AllocObject ref) {
+        assert size >= objectOverhead.getOverhead()
+                : "The object size cannot be smaller than the overhead(" + objectOverhead + ").";
         BytesAllocated.add(size);
         return new AllocObject(size, ref);
     }
@@ -106,8 +112,7 @@ class AllocObject {
      * The enumeration to AllocObject overhead in heap.
      */
     static class ObjectOverhead {
-        private final int overhead = (int) ClassLayout.parseClass(AllocObject.class).instanceSize();
-
+        private final int overhead = (int) GraphLayout.parseInstance(new AllocObject(0)).totalSize();
         int getOverhead() {
             return overhead;
         }

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/HyperAlloc.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/HyperAlloc.java
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.benchmark.hyperalloc;
 
+import org.openjdk.jol.info.ClassLayout;
+
 public final class HyperAlloc {
     private static final String DEFAULT_RUN_TYPE = "simple";
 
     private HyperAlloc() {}
 
     public static void main(String[] args) {
+
+        System.out.println(ClassLayout.parseClass(AllocObject.class).instanceSize());
 
         switch (findRunType(args)) {
             case "simple" :

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunConfig.java
@@ -52,7 +52,13 @@ public class SimpleRunConfig {
             } else if (args[i].equals("-t")) {
                 numOfThreads = Integer.parseInt(args[++i]);
             } else if (args[i].equals("-n")) {
-                minObjectSize = Integer.parseInt(args[++i]);
+                int requestedMinObjectSize = Integer.parseInt(args[++i]);
+                if (requestedMinObjectSize < AllocObject.getObjectOverhead()) {
+                    System.out.println("Minimum object size includes the object header, minimum object size is: " + AllocObject.getObjectOverhead());
+                    minObjectSize = AllocObject.getObjectOverhead();
+                } else {
+                    minObjectSize = requestedMinObjectSize;
+                }
             } else if (args[i].equals("-x")) {
                 maxObjectSize = Integer.parseInt(args[++i]);
             } else if (args[i].equals("-r")) {
@@ -121,7 +127,7 @@ public class SimpleRunConfig {
         this.midAgedInMb = midAgedInMb;
         this.durationInSecond = durationInSecond;
         this.numOfThreads = numOfThreads;
-        this.minObjectSize = minObjectSize;
+        this.minObjectSize = Math.max(minObjectSize, AllocObject.getObjectOverhead());
         this.maxObjectSize = maxObjectSize;
         this.pruneRatio = pruneRatio;
         this.reshuffleRatio = reshuffleRatio;

--- a/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
+++ b/HyperAlloc/src/main/java/com/amazon/corretto/benchmark/hyperalloc/SimpleRunner.java
@@ -39,8 +39,6 @@ public class SimpleRunner extends TaskBase {
     public void start() {
         System.out.println("Starting a SimpleRunner");
         try {
-            AllocObject.setOverhead(config.isUseCompressedOops() ? AllocObject.ObjectOverhead.CompressedOops
-                    : AllocObject.ObjectOverhead.NonCompressedOops);
             final ObjectStore store = new ObjectStore(config.getLongLivedInMb(), config.getPruneRatio(),
                     config.getReshuffleRatio());
             final Thread storeThread = new Thread(store);

--- a/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/AllocObjectTest.java
+++ b/HyperAlloc/src/test/java/com/amazon/corretto/benchmark/hyperalloc/AllocObjectTest.java
@@ -78,36 +78,4 @@ class AllocObjectTest {
             assertThat(size, lessThan(i + 8));
         }
     }
-
-    @Test
-    void OverheadTest() {
-        AllocObject.setOverhead(AllocObject.ObjectOverhead.CompressedOops);
-        assertDoesNotThrow(() -> AllocObject.create(40, 40, null));
-        AllocObject.setOverhead(AllocObject.ObjectOverhead.NonCompressedOops);
-        assertThrows(AssertionError.class, () -> AllocObject.create(40, 40, null));
-        assertDoesNotThrow(() -> AllocObject.create(56, 56, null));
-
-        AllocObject.setOverhead(AllocObject.ObjectOverhead.CompressedOops);
-    }
-
-    @Test
-    @Disabled("Only run when compressed oops disabled.")
-    void ObjectSizeNoCompressedOopsTest() {
-        AllocObject.setOverhead(AllocObject.ObjectOverhead.NonCompressedOops);
-
-        final AllocObject o1 = new AllocObject(56, null);
-        final AllocObject o2 = new AllocObject(57, null);
-        final AllocObject o3 = new AllocObject(58, null);
-        final AllocObject o4 = new AllocObject(59, null);
-        final AllocObject o5 = new AllocObject(65, null);
-
-        final AllocObject o6 = new AllocObject(1024, null);
-
-        assertThat(o1.getRealSize(), is(56));
-        assertThat(o2.getRealSize(), is(64));
-        assertThat(o3.getRealSize(), is(64));
-        assertThat(o4.getRealSize(), is(64));
-        assertThat(o5.getRealSize(), is(72));
-        assertThat(o6.getRealSize(), is(1024));
-    }
 }


### PR DESCRIPTION
[74](https://github.com/corretto/heapothesys/issues/74)

The size of objects to allocate in HyperAlloc _includes_ the header. The header size may vary for many reasons (compressed vs. uncompressed oops, compact object headers, etc). Instead of hard coding various expected sizes for different runtime configurations, use the [Java Object Layout](https://github.com/openjdk/jol/) project to determine the overhead of `AllocObject` and enforce this as the minimum size.