### PR TITLE
Report that intended customer interactions happen

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -455,7 +455,27 @@ public class Bootstrap extends ExtrememThread {
 
     server_accumulator.reportPercentiles(this, config.ReportCSV());
     customer_accumulator.reportPercentiles(this, config.ReportCSV());
-      
+
+    int customer_thread_count = config.CustomerThreads();
+    RelativeTime customer_period = config.CustomerPeriod();
+    RelativeTime simulation_duration = config.SimulationDuration();
+    int activations_per_thread = (int) simulation_duration.divideBy(this, customer_period);
+    int expected_activations = customer_thread_count * activations_per_thread;
+    int actual_activations = customer_accumulator.engagements();
+
+    Report.acquireReportLock();
+    Report.output();
+    if (config.ReportCSV()) {
+      Report.output("Observed Customer Transactions, Expected Customer Transactions");
+      Report.output(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations));
+    } else {
+      String judgement = (actual_activations >= expected_activations)? "Looks good: ": "PROBLEM: ";
+      Report.output(judgement, "observed ", String.valueOf(actual_activations),
+		      " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
+    }
+    Report.output();
+    Report.releaseReportLock();
+
     customer_accumulator = null;
     customer_alloc_accumulator  = null;
     customer_garbage_accumulator = null;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
@@ -168,6 +168,10 @@ class CustomerLog extends ExtrememObject {
     delta.garbageFootprint(t);
   }
 
+  int engagements() {
+    return engagements;
+  }
+
   void report(ExtrememThread t, String label, boolean reportCSV) {
     String s;
     int l;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTime.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTime.java
@@ -246,7 +246,7 @@ class RelativeTime extends HighResolutionTime {
 
   /**
    * Return a new Ephemeral RelativeTime instance representing the
-   * quotient of dividing this by factor.
+   * quotient of dividing this by divisor.
    *
    * The code that invokes this service is expected to account for the
    * returned RelativeTime object's memory eventually becoming garbage,
@@ -257,6 +257,15 @@ class RelativeTime extends HighResolutionTime {
     long ns = this.ns / (long) divisor;
     long s = this.s / divisor;
     return new RelativeTime(t, s, (int) ns);
+  }
+
+  /**
+   * Return a primitive double representing the quotient of dividing this by divisor.
+   */
+  double divideBy(ExtrememThread t, RelativeTime divisor) {
+    double my_time = this.s + this.ns / 1_000_000_000.0;
+    double divisor_time = divisor.s + divisor.ns / 1_000_000_000.0;
+    return my_time / divisor_time;
   }
 
   /**


### PR DESCRIPTION
If the configuration is under provisioned, fewer transactions than intended will occur.  In this case, the percentile response times are not meaningful for comparison with other configurations that did process all of the intended transactions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
