### PR TITLE
Relax testing for goodness of results

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -465,13 +465,22 @@ public class Bootstrap extends ExtrememThread {
 
     Report.acquireReportLock();
     Report.output();
+    // Allow observed count to be no more than customer_thread_count less than the expected activations.
+    // It may be less, depending on when particular threads receive their termination signal at the end of simulation.
+    String judgement = (actual_activations + customer_thread_count >= expected_activations)? "Looks good: ": "PROBLEM: ";
     if (config.ReportCSV()) {
-      Report.output("Observed Customer Transactions, Expected Customer Transactions");
-      Report.output(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations));
+      Report.output(judgement,
+		    "Observed customer transactions should be no less than expected customer transactions minus",
+		    " the number of customer threads");
+      Report.output("Observed Customer Transactions, Expected Customer Transactions, CustomerThreads");
+      Report.output(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations),
+		    ", ", String.valueOf(customer_thread_count));
     } else {
-      String judgement = (actual_activations >= expected_activations)? "Looks good: ": "PROBLEM: ";
       Report.output(judgement, "observed ", String.valueOf(actual_activations),
-		      " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
+		    " customer interactions out of at least (",
+		    String.valueOf(expected_activations - customer_thread_count), " = ",
+		    String.valueOf(expected_activations), " expected transactions minus ",
+		    String.valueOf(customer_thread_count), " customer threads)");
     }
     Report.output();
     Report.releaseReportLock();

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
@@ -121,6 +121,20 @@ class Report {
   }
 
   static void output(String s1, String s2, String s3, String s4, String s5,
+                     String s6, String s7, String s8, String s9, String s10) {
+    out.print(s1);
+    out.print(s2);
+    out.print(s3);
+    out.print(s4);
+    out.print(s5);
+    out.print(s6);
+    out.print(s7);
+    out.print(s8);
+    out.print(s9);
+    out.println(s10);
+  }
+
+  static void output(String s1, String s2, String s3, String s4, String s5,
                      String s6, String s7, String s8, String s9, String s10,
                      String s11, String s12, String s13, String s14,
                      String s15) {


### PR DESCRIPTION

Previous implementation only considers test run "good" if the number of completed customer interactions is at least the number of customer threads multiplied by the simulation duration divided by the CustomerThinkTime.  Due to the possibility that certain customer threads may be terminated before they have had a chance to attempt their last interaction, this PR considers "good" a simulation for which the number of completed customer interactions is not more than the number of customer threads fewer than "expected transactions".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
