### PR TITLE
Add an option to match only Products whose name and description both hold every searched keyword

### DIFF
--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -139,8 +139,8 @@ If AllowAnyMatch is true, then products containing at least one of the keywords 
 is false, then only products that contain all of the keywords are considered to match the inquiry.  Note that overriding the
 default value of AllowAnyMatch will generally result in far fewer candidate products to be compared and evaluated.  With some
 product data bases, the difference between AllowAnyMatch = true and AllowAnyMatch = false is over 5,000:1.  Setting this
-paramater to false is especially useful when running with very large Product data bases.  When AllowAnyMatch is false,
-a different more efficient algorithm is used to calculate the intersection of products matchine all search criteria.
+parameter to false is especially useful when running with very large Product data bases.  When AllowAnyMatch is false,
+a different more efficient algorithm is used to calculate the intersection of products matching all search criteria.
 
 ### *-dProductReviewLength=32*
 

--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -140,7 +140,8 @@ is false, then only products that contain all of the keywords are considered to 
 default value of AllowAnyMatch will generally result in far fewer candidate products to be compared and evaluated.  With some
 product data bases, the difference between AllowAnyMatch = true and AllowAnyMatch = false is over 5,000:1.  Setting this
 parameter to false is especially useful when running with very large Product data bases.  When AllowAnyMatch is false,
-a different more efficient algorithm is used to calculate the intersection of products matching all search criteria.
+a different more efficient algorithm is used to calculate the intersection of products matching all search criteria in
+the PhasedUpdates and FastAndFurious modes of operation.
 
 ### *-dProductReviewLength=32*
 

--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -132,6 +132,16 @@ Between the moment when a customer is presented with the results of a product se
 
 Each customer inquiry consists of a string of this many randomly selected words.  Increasing this number results in an increase in the memory allocated during formulation of each customer inquiry and generally results in an increased number of candidate products that match the inquiry.  This in turn results in more transient memory allocation and more effort in deciding between multiple alternative products that match a given decision criteria.
 
+### *-dAllowAnyMatch=true*
+
+By default, each customer inquiry searches the Products data base for products that match the randomly generated keywords.
+If AllowAnyMatch is true, then products containing at least one of the keywords are considered a search match.  If AllowAnyMatch
+is false, then only products that contain all of the keywords are considered to match the inquiry.  Note that overriding the
+default value of AllowAnyMatch will generally result in far fewer candidate products to be compared and evaluated.  With some
+product data bases, the difference between AllowAnyMatch = true and AllowAnyMatch = false is over 5,000:1.  Setting this
+paramater to false is especially useful when running with very large Product data bases.  When AllowAnyMatch is false,
+a different more efficient algorithm is used to calculate the intersection of products matchine all search criteria.
+
 ### *-dProductReviewLength=32*
 
 Each time a product is found to match a particular customer inquiry, the simulation randomly generates a product review containing this many words.  Product reviews represent thread-local data that is allocated before the customer begins to think about the choice between multiple candidate products.  The data is not discarded until after the customer has made this choice.  The final selection between multiple candidate products depends on how well the respective product reviews match the customer's selection criteria.  Increasing this value results in an increase in ephemeral and transient memory allocation and an increase in the effort required to compute the goodness of matches against the customer's selection criteria.

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -94,24 +94,20 @@ public class Bootstrap extends ExtrememThread {
     Util.referenceArray(this, LifeSpan.NearlyForever,
                         config.SalesTransactionQueueCount());
     for (int i = 0; i < config.SalesTransactionQueueCount(); i++)
-      sales_queues[i] = new SalesTransactionQueue(this,
-                                                  LifeSpan.NearlyForever);
-    BrowsingHistoryQueue[] browsing_queues = (
-      new BrowsingHistoryQueue[config.BrowsingHistoryQueueCount()]);
+      sales_queues[i] = new SalesTransactionQueue(this, LifeSpan.NearlyForever);
+    BrowsingHistoryQueue[] browsing_queues = new BrowsingHistoryQueue[config.BrowsingHistoryQueueCount()];
     Util.referenceArray(this, LifeSpan.NearlyForever,
                         config.BrowsingHistoryQueueCount());
     for (int i = 0; i < config.BrowsingHistoryQueueCount(); i++)
-      browsing_queues[i] = new BrowsingHistoryQueue(this,
-                                                    LifeSpan.NearlyForever);
+      browsing_queues[i] = new BrowsingHistoryQueue(this, LifeSpan.NearlyForever);
     Trace.msg(4, "browsing_queues and sales_queues established");
-      
     Products all_products = (
       new Products(this, LifeSpan.NearlyForever, config));
     Trace.msg(4, "all_products established");
-    Customers all_customers = new Customers(this, LifeSpan.NearlyForever,
-                                            config);
+
+    Customers all_customers = new Customers(this, LifeSpan.NearlyForever, config);
     Trace.msg(4, "all_customers established");
-      
+
     if (config.CustomerThreads() > 0) {
       // Stagger the Customer threads so they are not all triggered at
       // the same moment in time.
@@ -172,7 +168,7 @@ public class Bootstrap extends ExtrememThread {
     }
     Trace.msg(2, "starting up ServerThreads: ",
               Integer.toString(config.ServerThreads()));
-      
+
     server_threads = new ServerThread[config.ServerThreads()];
     Util.referenceArray(this, LifeSpan.NearlyForever, config.ServerThreads());
       

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -396,98 +396,102 @@ class Configuration {
   }
 
   void doUintArg(int index, String keyword, String uintString) {
-    int u = 0;
+    long u = 0;
     for (int i = 0; i < uintString.length(); i++) {
       char c = uintString.charAt(i);
       if (!Character.isDigit(c))
         usage("Unexpected character in unsigned int encoding");
       u = u * 10 + Character.digit(c, 10);
     }
+    if (u > Integer.MAX_VALUE) {
+      usage("argument must be no greater than Integer.MAX_VALUE: " + Long.toString(u));
+    }
+    int ui = (int) u;
 
     switch (index) {
       case 0:
         if (keyword.equals("BrowsingHistoryQueueCount")) {
-          BrowsingHistoryQueueCount = u;
+          BrowsingHistoryQueueCount = ui;
           break;
         }
       case 1:
         if (keyword.equals("CustomerReplacementCount")) {
-          CustomerReplacementCount = u;
+          CustomerReplacementCount = ui;
           break;
         }
       case 2:
         if (keyword.equals("CustomerThreads")) {
-          CustomerThreads = u;
+          CustomerThreads = ui;
           break;
         }
       case 3:
         if (keyword.equals("DictionarySize")) {
-          DictionarySize = u;
+          DictionarySize = ui;
           break;
         }
       case 4:
         if (keyword.equals("KeywordSearchCount")) {
-          KeywordSearchCount = u;
+          KeywordSearchCount = ui;
           break;
         }
       case 5:
         if (keyword.equals("MaxArrayLength")) {
-          MaxArrayLength = u;
+          MaxArrayLength = ui;
           break;
         }
       case 6:
         if (keyword.equals("NumCustomers")) {
-          NumCustomers = u;
+          NumCustomers = ui;
           break;
         }
       case 7:
         if (keyword.equals("NumProducts")) {
-          NumProducts = u;
+          NumProducts = ui;
           break;
         }
       case 8:
         if (keyword.equals("ProductDescriptionLength")) {
-          ProductDescriptionLength = u;
+          ProductDescriptionLength = ui;
           break;
         }
       case 9:
         if (keyword.equals("ProductNameLength")) {
-          ProductNameLength = u;
+          ProductNameLength = ui;
           break;
         }
       case 10:
         if (keyword.equals("ProductReplacementCount")) {
-          ProductReplacementCount = u;
+          ProductReplacementCount = ui;
           break;
         }
       case 11:
         if (keyword.equals("ProductReviewLength")) {
-          ProductReviewLength = u;
+          ProductReviewLength = ui;
           break;
         }
       case 12:
         if (keyword.equals("RandomSeed")) {
-          RandomSeed = u;
+          RandomSeed = ui;
           break;
         }
       case 13:
         if (keyword.equals("ResponseTimeMeasurements")) {
-          ResponseTimeMeasurements = u;
+          ResponseTimeMeasurements = ui;
           break;
         }
       case 14:
         if (keyword.equals("SalesTransactionQueueCount")) {
-          SalesTransactionQueueCount = u;
+          SalesTransactionQueueCount = ui;
           break;
         }
       case 15:
         if (keyword.equals("SelectionCriteriaCount")) {
-          SelectionCriteriaCount = u;
+          SelectionCriteriaCount = ui;
           break;
         }
       case 16:
         if (keyword.equals("ServerThreads")) {
-          ServerThreads = u;
+          ServerThreads = ui;
           break;
         }
       default:

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -39,6 +39,7 @@ class Configuration {
   static final boolean DefaultReportCSV = false;
   static final boolean DefaultFastAndFurious = false;
   static final boolean DefaultPhasedUpdates = false;
+  static final boolean DefaultAllowAnyMatch = true;
 
   static final int DefaultDictionarySize = 25000;
   static final String DefaultDictionaryFile = "/usr/share/dict/words";
@@ -97,6 +98,7 @@ class Configuration {
   private int CustomerThreads;
   private int ServerThreads;
 
+  private boolean AllowAnyMatch;
   private boolean FastAndFurious;
   private boolean PhasedUpdates;;
   private boolean ReportIndividualThreads;
@@ -203,6 +205,7 @@ class Configuration {
     ProductReviewLength = DefaultProductReviewLength;
     RandomSeed = DefaultRandomSeed;
 
+    AllowAnyMatch = DefaultAllowAnyMatch;
     FastAndFurious = DefaultFastAndFurious;
     PhasedUpdates = DefaultPhasedUpdates;
 
@@ -259,6 +262,7 @@ class Configuration {
   }
 
   private static String[] boolean_patterns = {
+    "AllowAnyMatch",
     "FastAndFurious",
     "PhasedUpdates",
     "ReportCSV",
@@ -362,21 +366,26 @@ class Configuration {
 
     switch (index) {
       case 0:
+        if (keyword.equals("AllowAnyMatch")) {
+	  AllowAnyMatch = b;
+          break;
+        }
+      case 1:
         if (keyword.equals("FastAndFurious")) {
           FastAndFurious = b;
           break;
         }
-      case 1:
+      case 2:
         if (keyword.equals("PhasedUpdates")) {
           PhasedUpdates = b;
           break;
         }
-      case 2:
+      case 3:
         if (keyword.equals("ReportCSV")) {
           ReportCSV = b;
           break;
         }
-      case 3:
+      case 4:
         if (keyword.equals("ReportIndividualThreads")) {
           ReportIndividualThreads = b;
           break;
@@ -659,6 +668,12 @@ class Configuration {
     if (NumCustomers < 1)
       usage("NumCustomers must be greater or equal to 1");
 
+    RelativeTime Zero = new RelativeTime(t);
+    if (PhasedUpdateInterval.compare(Zero) == 0) {
+      usage("PhasedUpdateInterval must be greater than 0");
+    }
+    Zero.garbageFootprint(t);
+
     if (!sufficientVocabulary(DictionarySize, ProductNameLength, NumProducts))
       usage("Dictionary too small to generate unique product names");
 
@@ -754,6 +769,10 @@ class Configuration {
 
   boolean FastAndFurious() {
     return FastAndFurious;
+  }
+
+  boolean AllowAnyMatch() {
+    return AllowAnyMatch;
   }
 
   boolean PhasedUpdates() {
@@ -902,6 +921,7 @@ class Configuration {
                   FastAndFurious? "true": "false");
     Report.output("PhasedUpdates,",
                   PhasedUpdates? "true": "false");
+
     Report.output();
     s = Long.toString(PhasedUpdateInterval.microseconds());
     l = s.length();
@@ -1039,6 +1059,9 @@ class Configuration {
     Report.output("KeywordSearchCount,", s);
     Util.abandonEphemeralString(t, l);
 
+    Report.output("AllowAnyMatch,", 
+                  AllowAnyMatch? "true": "false");
+
     s = Integer.toString(SelectionCriteriaCount);
     l = s.length();
     Util.ephemeralString(t, l);
@@ -1084,7 +1107,6 @@ class Configuration {
     Report.output("ProductReviewLength,", s);
     Util.abandonEphemeralString(t, l);
 
-
   }
 
   void dump(ExtrememThread t) {
@@ -1110,13 +1132,15 @@ class Configuration {
 
     Report.output("  Fine-grain locking of data base (FastAndFurious): ", FastAndFurious? "true": "false");
     Report.output("       Rebuild data base in phases (PhasedUpdates): ", PhasedUpdates? "true": "false");
-    Report.output();
-    s = PhasedUpdateInterval.toString(t);
-    l = s.length();
-    Util.ephemeralString(t, l);
-    Report.output("  Time between data rebuild (PhasedUpdateInterval): ", s);
-    Util.abandonEphemeralString(t, l);
 
+    Report.output();
+    if (PhasedUpdates) {
+      s = PhasedUpdateInterval.toString(t);
+      l = s.length();
+      Util.ephemeralString(t, l);
+      Report.output("  Time between data rebuild (PhasedUpdateInterval): ", s);
+      Util.abandonEphemeralString(t, l);
+    }
 
     s = Integer.toString(RandomSeed);
     l = s.length();
@@ -1235,6 +1259,9 @@ class Configuration {
     Util.ephemeralString(t, l);
     Report.output("                Words in query (KeywordSearchCount): ", s);
     Util.abandonEphemeralString(t, l);
+
+    Report.output("                  Allow lookup to match any keyword\n" +
+		 "(if it fails to match all keywords)  (AllowAnyMatch): ", AllowAnyMatch? "true": "false");
 
     s = Integer.toString(SelectionCriteriaCount);
     l = s.length();

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Customer.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Customer.java
@@ -208,7 +208,7 @@ class Customer extends ExtrememObject {
     log.accumulate(ls, MemoryFlavor.ObjectReference, p, count * 2);
     // And two long fields: id, purchase_hash, and two int fields: fsfl, csfl
     log.accumulate(ls, MemoryFlavor.ObjectRSB, p,
-                   count * 2 * (Util.SizeOfLong + Util.SizeOfInt));
+                   ((long) count) * 2 * (Util.SizeOfLong + Util.SizeOfInt));
 
     // account for the accumulation of allocated arrays referenced
     // from each Customer's sflq field.

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -107,7 +107,12 @@ class CustomerThread extends ExtrememThread {
       // keywords, all, any are all treated as Ephemeral.
       String[] keywords = randomKeywords(config.KeywordSearchCount());
       Product[] all = all_products.lookupProductsMatchingAll(this, keywords);
-      Product[] any = all_products.lookupProductsMatchingAny(this, keywords);
+      Product[] any;
+      if (config.AllowAnyMatch()) {
+	any = all_products.lookupProductsMatchingAny(this, keywords);
+      } else {
+	any = new Product[0];
+      }
       
       int all_count = all.length;
       int any_count = any.length;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ExtrememThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ExtrememThread.java
@@ -93,11 +93,28 @@ abstract class ExtrememThread extends java.lang.Thread {
     return random.nextDouble();
   }
 
+  // Assume keywords[0..num_keywords - 2] are independent.  Return true iff keyword[num_keywords - 1] depends
+  // on one of the other keywords.  Keywords depend on each other if one is a substring of the other.
+  boolean keywords_are_dependent(String[] keywords, int num_keywords) {
+    String last_keyword = keywords[num_keywords - 1];
+    // make sure existing keywords are not substrings of new keyword
+    for (int i = 0; i < num_keywords - 1; i++) {
+      if (keywords[i].indexOf(last_keyword) >= 0) {
+	return true;
+      } else if (last_keyword.indexOf(keywords[i]) >= 0) {
+	return true;
+      }
+    }
+    return false;
+  }
+
   // Result is assumed to be LifeSpan.Ephemeral.
   String[] randomKeywords(int count) {
     String[] result = new String[count];
     for (int i = 0; i < count; i++) {
-      result[i] = randomWord();
+      do {
+	result[i] = randomWord();
+      } while (keywords_are_dependent(result, i));
     }
     memory_log.accumulate(LifeSpan.Ephemeral, MemoryFlavor.ArrayObject,
                           Polarity.Expand, 1);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ExtrememThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ExtrememThread.java
@@ -96,12 +96,13 @@ abstract class ExtrememThread extends java.lang.Thread {
   // Assume keywords[0..num_keywords - 2] are independent.  Return true iff keyword[num_keywords - 1] depends
   // on one of the other keywords.  Keywords depend on each other if one is a substring of the other.
   boolean keywords_are_dependent(String[] keywords, int num_keywords) {
+    if (num_keywords <= 1) {
+      return false;
+    }
     String last_keyword = keywords[num_keywords - 1];
     // make sure existing keywords are not substrings of new keyword
     for (int i = 0; i < num_keywords - 1; i++) {
-      if (keywords[i].indexOf(last_keyword) >= 0) {
-	return true;
-      } else if (last_keyword.indexOf(keywords[i]) >= 0) {
+      if (keywords[i].equals(last_keyword)) {
 	return true;
       }
     }
@@ -114,7 +115,7 @@ abstract class ExtrememThread extends java.lang.Thread {
     for (int i = 0; i < count; i++) {
       do {
 	result[i] = randomWord();
-      } while (keywords_are_dependent(result, i));
+      } while (keywords_are_dependent(result, i + 1));
     }
     memory_log.accumulate(LifeSpan.Ephemeral, MemoryFlavor.ArrayObject,
                           Polarity.Expand, 1);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/MemoryLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/MemoryLog.java
@@ -102,9 +102,8 @@ public class MemoryLog {
     // Tallies should never go negative.  The only reason to decrement
     // a tally is to undo a previous increment.
     if (tallies[ls.ordinal()][mf.ordinal()] < 0)
-      throw new IllegalStateException("Negative memory tally for [" +
-                                      ls + ", " + mf + "] after count "
-                                      + count + " with Polarity " + p );
+      throw new IllegalStateException("Negative memory tally for ["
+				      +  ls + ", " + mf + "] after count " + count + " with Polarity " + p );
   }
 
   void tallyMemory(MemoryLog log, LifeSpan ls, Polarity p) {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Product.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Product.java
@@ -69,7 +69,7 @@ class Product extends ExtrememObject {
     log.accumulate(ls, MemoryFlavor.ObjectReference, p, count * 2);
     // Account for id, available
     log.accumulate(ls, MemoryFlavor.ObjectRSB, p,
-                   count * (Util.SizeOfLong + Util.SizeOfBoolean));
+                   ((long) count) * (Util.SizeOfLong + Util.SizeOfBoolean));
 
   }
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
@@ -494,7 +494,7 @@ class Products extends ExtrememObject {
   }
 
   /**
-   * Compute the union of sets represented by all_matches[0..all_count-1] and new_matches[0..length()-1]
+   * Compute the intersection of sets represented by all_matches[0..all_count-1] and new_matches[0..length()-1]
    *
    * On entry, all_matches are new_matches are sorted in increasing order.
    *

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
@@ -496,7 +496,7 @@ class Products extends ExtrememObject {
   /**
    * Compute the intersection of sets represented by all_matches[0..all_count-1] and new_matches[0..length()-1]
    *
-   * On entry, all_matches are new_matches are sorted in increasing order.
+   * On entry, all_matches and new_matches are sorted in increasing order.
    *
    * On return, valid entries (entries that were present in both arrays on entry) of the all_matches[] array
    * are sifted to the front of that array.  The return value represents the number of valid entries within

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
@@ -615,7 +615,7 @@ class Products extends ExtrememObject {
 	  quicksort(new_matches, 0, new_matches_size - 1);
 	  //	  dumpArray("After sorting supplemental array", new_matches, new_matches_size);
 	  intersection_size = filter_out(intersection_size, all_matches, new_matches);
-	  dumpArray("After filtering original array", all_matches, intersection_size);
+	  //      dumpArray("After filtering original array", all_matches, intersection_size);
 	  Util.abandonEphemeralRSBArray(t, new_matches_size, Util.SizeOfLong);
 	}
       }

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
@@ -100,6 +100,8 @@ class Products extends ExtrememObject {
     }
   }
 
+  private final boolean do_fast_match_all;
+
   // The change_log is only used if config.PhasedUpdates
   final ChangeLog change_log;
 
@@ -223,6 +225,7 @@ class Products extends ExtrememObject {
 
   Products (ExtrememThread t, LifeSpan ls, Configuration config) {
     super(t, ls);
+    this.do_fast_match_all = !config.AllowAnyMatch();
 
     if (config.PhasedUpdates()) {
       change_log = new ChangeLog();
@@ -490,77 +493,235 @@ class Products extends ExtrememObject {
     // This race is handled elsewhere.
   }
 
-  Product[] lookupProductsMatchingAllPhasedUpdates(ExtrememThread t, String[] keywords, CurrentProductsData current) {
-    ExtrememHashSet<Product> intersection = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
-    for (int i = 0; i < keywords.length; i++) {
-      String keyword = keywords[i];
-      if (i == 0) {
-        ExtrememHashSet<Long> matched_ids;
-        matched_ids = current.nameIndex().get(keyword);
-        if (matched_ids != null) {
-          Util.createEphemeralHashSetIterator(t);
-          for (Long id: matched_ids) {
-            addToSetIfAvailable(t, intersection, id);
-          }
-          Util.abandonEphemeralHashSetIterator(t);
-        }
-        matched_ids = current.descriptionIndex().get(keyword);
-        if (matched_ids != null) {
-          Util.createEphemeralHashSetIterator(t);
-          for (Long id: matched_ids) {
-            addToSetIfAvailable(t, intersection, id);
-          }
-          Util.abandonEphemeralHashSetIterator(t);
-        }
-      } else {
-        ExtrememHashSet<Long> matched_ids;
-        ExtrememHashSet<Product> new_matches = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
-        matched_ids = current.nameIndex().get(keyword);
-        if (matched_ids != null) {
-          Util.createEphemeralHashSetIterator(t);
-          for (Long id: matched_ids) {
-            addToSetIfAvailable(t, new_matches, id);
-          }
-          Util.abandonEphemeralHashSetIterator(t);
-        }
-        matched_ids = current.descriptionIndex().get(keyword);
-        if (matched_ids != null) {
-          Util.createEphemeralHashSetIterator(t);
-          for (Long id: matched_ids) {
-            addToSetIfAvailable(t, new_matches, id);
-          }
-          Util.abandonEphemeralHashSetIterator(t);
-        }
-        ExtrememHashSet<Product> remove_set = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
-        Util.createEphemeralHashSetIterator(t);
-        for (Product p: intersection) {
-          if (!new_matches.contains(p)) {
-            remove_set.add(t, p);
-          }
-        }
-        Util.abandonEphemeralHashSetIterator(t);
-        new_matches.garbageFootprint(t);
-        Util.createEphemeralHashSetIterator(t);
-        for (Product p: remove_set) {
-          intersection.remove(t, p);
-        }
-        Util.abandonEphemeralHashSetIterator(t);
-        remove_set.garbageFootprint(t);
-        if (intersection.size() == 0) {
-          Util.ephemeralReferenceArray(t, 0);
-          // Returning an array with no entries.
-          return new Product[0];
-        }
+  /**
+   * Compute the union of sets represented by all_matches[0..all_count-1] and new_matches[0..length()-1]
+   *
+   * On entry, all_matches are new_matches are sorted in increasing order.
+   *
+   * On return, valid entries (entries that were present in both arrays on entry) of the all_matches[] array
+   * are sifted to the front of that array.  The return value represents the number of valid entries within
+   * the union of the two arrays.
+   */
+  int filter_out(int all_count, long all_matches[], long new_matches[]) {
+    int all_idx = 0;
+    int slide_idx = 0;
+    int new_idx = 0;
+    int new_length = new_matches.length;
+
+    while (all_idx < all_count) {
+      long next_all_candidate = all_matches[all_idx];
+      while ((new_idx < new_length) && (new_matches[new_idx] < next_all_candidate)) {
+        new_idx++;
+      }
+      if ((new_idx < new_length) && (new_matches[new_idx] == next_all_candidate)) {  // Preserve this value
+	if (slide_idx < new_idx) {
+          all_matches[slide_idx++] = all_matches[all_idx++];
+	} else {
+	  slide_idx++;
+	  all_idx++;
+	}
+      } else {  // discard this value from all_matches because it's not present in new_matches array
+	all_idx++;
       }
     }
-    Product[] result = new Product[intersection.size()];
-    Util.ephemeralReferenceArray(t, result.length);
-    int j = 0;
-    Util.createEphemeralHashSetIterator(t);
-    for (Product p: intersection)
-      result[j++] = p;
-    Util.abandonEphemeralHashSetIterator(t);
-    intersection.garbageFootprint(t);
+    return slide_idx;
+  }
+
+  int partition(long array[], int first, int last) {
+    long pivot = array[last];
+    int i = first - 1;
+    for (int j = first; j < last; j++) {
+      if (array[j] <= pivot) {
+	i++;
+	long tmp = array[i];
+	array[i] = array[j];
+	array[j] = tmp;
+      }
+    }
+    long tmp = array[i+1];
+    array[i + 1] = array[last];
+    array[last] = tmp;
+    return i + 1;
+  }
+
+  void quicksort(long array[], int first, int last) {
+    if (first < last) {
+      int partition_index = partition(array, first, last);
+      quicksort(array, first, partition_index - 1);
+      quicksort(array, partition_index + 1, last);
+    }
+  }
+
+  void dumpArray(String msg, long array[], int length) {
+      Report.output();
+      Report.outputNoLine(msg, ": dumpArray[", Integer.toString(length), "] ");
+      for (int i = 0; i < length; i++) {
+	  Report.outputNoLine(Long.toString(array[i]), " ");
+      }
+      Report.output();
+  }
+
+  Product[] lookupProductsMatchingAllPhasedUpdates(ExtrememThread t, String[] keywords, CurrentProductsData current) {
+    Product[] result;
+
+    // Note: For proper tally of allocated memory, we should abandon name_matched_ids and description_matched_ids
+    // within each iteration of loop.
+    if (this.do_fast_match_all) {
+      int intersection_size = 0;
+      long all_matches[] = null;
+      for (int i = 0; i < keywords.length; i++) {
+        String keyword = keywords[i];
+
+        ExtrememHashSet<Long> name_matched_ids;
+        name_matched_ids = current.nameIndex().get(keyword);
+
+	ExtrememHashSet<Long> description_matched_ids;
+	description_matched_ids = current.descriptionIndex().get(keyword);
+
+	if (i == 0) {
+	  intersection_size = name_matched_ids.size() + description_matched_ids.size();
+	  Util.ephemeralRSBArray(t, intersection_size, Util.SizeOfLong);
+	  all_matches = new long[intersection_size];
+	  int dest_idx = 0;
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Long id: name_matched_ids) {
+	    all_matches[dest_idx++] = id.longValue();
+	  }
+	  Util.abandonEphemeralHashSetIterator(t);
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Long id: description_matched_ids) {
+	    all_matches[dest_idx++] = id.longValue();
+	  }
+	  Util.abandonEphemeralHashSetIterator(t);
+	  //	  dumpArray("Before sorting initial array", all_matches, intersection_size);
+	  quicksort(all_matches, 0, intersection_size - 1);
+	  //	  dumpArray("After sorting initial array", all_matches, intersection_size);
+	} else {
+	  int new_matches_size = name_matched_ids.size() + description_matched_ids.size();
+	  Util.ephemeralRSBArray(t, new_matches_size, Util.SizeOfLong);
+	  long new_matches[] = new long[new_matches_size];
+	  int dest_idx = 0;
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Long id: name_matched_ids) {
+	    new_matches[dest_idx++] = id.longValue();
+	  }
+	  Util.abandonEphemeralHashSetIterator(t);
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Long id: description_matched_ids) {
+	    new_matches[dest_idx++] = id.longValue();
+	  }
+	  Util.abandonEphemeralHashSetIterator(t);
+	  //	  dumpArray("Before sorting supplemental array", new_matches, new_matches_size);
+	  quicksort(new_matches, 0, new_matches_size - 1);
+	  //	  dumpArray("After sorting supplemental array", new_matches, new_matches_size);
+	  intersection_size = filter_out(intersection_size, all_matches, new_matches);
+	  dumpArray("After filtering original array", all_matches, intersection_size);
+	  Util.abandonEphemeralRSBArray(t, new_matches_size, Util.SizeOfLong);
+	}
+      }
+      result = new Product[intersection_size];
+      Util.ephemeralReferenceArray(t, intersection_size);
+      int cancel_count = 0;
+      for (int i = 0; i < intersection_size; i++) {
+	result[i] = product_map.get(all_matches[i]);
+	if (result[i] == null) {
+	  cancel_count++;
+	}
+      }
+      Util.abandonEphemeralRSBArray(t, all_matches.length, Util.SizeOfLong);
+      // In case any products have been cancelled during our concurrent lookup, filter them from the result
+      if (cancel_count > 0) {
+	Product original_result[] = result;
+	Util.ephemeralReferenceArray(t, intersection_size - cancel_count);
+	result = new Product[intersection_size - cancel_count];
+	int i = 0;
+	for (int j = 0; j < intersection_size; j++) {
+	  if (original_result[j] != null) {
+	    result[i++] = original_result[j];
+	  }
+	}
+	Util.abandonEphemeralReferenceArray(t, intersection_size);
+      }
+    } else {
+      // This is the original implementation.  It was written to "make work" and create garbage.  For some workloads,
+      // however, this creates so much work that GC interference gets lost in the noise.  With set sizes of 5,000,
+      // the time spent here is tens of ms.
+      ExtrememHashSet<Product> intersection = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
+      for (int i = 0; i < keywords.length; i++) {
+	String keyword = keywords[i];
+
+	if (i == 0) {
+	  ExtrememHashSet<Long> matched_ids;
+	  matched_ids = current.nameIndex().get(keyword);
+	  if (matched_ids != null) {
+	    Util.createEphemeralHashSetIterator(t);
+	    for (Long id: matched_ids) {
+	      addToSetIfAvailable(t, intersection, id);
+	    }
+	    Util.abandonEphemeralHashSetIterator(t);
+	  }
+
+	  matched_ids = current.descriptionIndex().get(keyword);
+	  if (matched_ids != null) {
+	    Util.createEphemeralHashSetIterator(t);
+	    for (Long id: matched_ids) {
+		addToSetIfAvailable(t, intersection, id);
+	    }
+	    Util.abandonEphemeralHashSetIterator(t);
+	  }
+	} else {
+	  ExtrememHashSet<Long> matched_ids;
+	  ExtrememHashSet<Product> new_matches = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
+	  matched_ids = current.nameIndex().get(keyword);
+	  if (matched_ids != null) {
+	    Util.createEphemeralHashSetIterator(t);
+	    for (Long id: matched_ids) {
+	      addToSetIfAvailable(t, new_matches, id);
+	    }
+	    Util.abandonEphemeralHashSetIterator(t);
+	  }
+
+	  matched_ids = current.descriptionIndex().get(keyword);
+	  if (matched_ids != null) {
+	    Util.createEphemeralHashSetIterator(t);
+	    for (Long id: matched_ids) {
+	      addToSetIfAvailable(t, new_matches, id);
+	    }
+	    Util.abandonEphemeralHashSetIterator(t);
+	  }
+	  ExtrememHashSet<Product> remove_set = new ExtrememHashSet<Product>(t, LifeSpan.Ephemeral);
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Product p: intersection) {
+	    if (!new_matches.contains(p)) {
+	      remove_set.add(t, p);
+	    }
+	  }
+	  Util.abandonEphemeralHashSetIterator(t);
+	  new_matches.garbageFootprint(t);
+	  Util.createEphemeralHashSetIterator(t);
+	  for (Product p: remove_set) {
+	    intersection.remove(t, p);
+	  }
+
+	  Util.abandonEphemeralHashSetIterator(t);
+	  remove_set.garbageFootprint(t);
+	  if (intersection.size() == 0) {
+	    Util.ephemeralReferenceArray(t, 0);
+	    // Returning an array with no entries.
+	    return new Product[0];
+	  }
+	}
+      }
+      result = new Product[intersection.size()];
+      Util.ephemeralReferenceArray(t, result.length);
+      int j = 0;
+      Util.createEphemeralHashSetIterator(t);
+      for (Product p: intersection) {
+	result[j++] = p;
+      }
+      Util.abandonEphemeralHashSetIterator(t);
+      intersection.garbageFootprint(t);
+    }
     return result;
   }
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
@@ -59,6 +59,19 @@ class Report {
     out.print(s2);
   }
 
+  static void outputNoLine(String s1, String s2, String s3) {
+    out.print(s1);
+    out.print(s2);
+    out.print(s3);
+  }
+
+  static void outputNoLine(String s1, String s2, String s3, String s4) {
+    out.print(s1);
+    out.print(s2);
+    out.print(s3);
+    out.print(s4);
+  }
+
   static void output(String s1, String s2) {
     out.print(s1);
     out.println(s2);


### PR DESCRIPTION
Before this PR, we would find two sets of products.  One set matches all Products whose name or description contain at least one of the searched keywords (the any candidates).  The other set matches only Products whose name or description contain all of the searched keywords (the all candidates).  If the all-candidates set was non-empty, we would use this set to be evaluated further.  If the all-candidates set was empty, we would the any-candidates set to be evaluated further.  With smaller Product data bases, this might represent variation of 100:1 in work required for each transaction.  This was designed to simulate variation in control paths that is typical in real-world applications, but perhaps not always found in synthetic benchmarks.

We have found that with very large data bases, the variation in work between any-candidates and all-candidates might be 5,000:1.  This extremely high variation in raw computation may hide the smaller impacts of alternative GC algorithms and configurations.  Using -dAllowAllMatches=false configuration allows Extremem to reduce the overhead of each inquiry to allow GC overheads to be monitored more closely.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
