### PR TITLE
Search for max transaction rate

### DIFF
--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -128,6 +128,90 @@ Each Customer thread waits this amount of time between starts of simulated custo
 
 Between the moment when a customer is presented with the results of a product search inquiry and the moment when the customer actually makes a decision regarding which product, if any, to purchase, the customer simply sleeps for this amount of time.  Shortening this time and shortening the CustomerPeriod allows more transactions to occur more quickly.  Lengthening this time causes an increase in the lifespan of transient objects which might accidentally be promoted into the older generation with certain garbage collection techniques.
 
+### *-dMaxP50CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P50 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP95CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P95 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP99CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P99 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP99_9CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P99_9 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP99_99CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P99_99 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP99_999CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P99_999 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
+### *-dMaxP100CustomerPrepMicroseconds=0s*
+
+If set to a non-zero value, this represents an SLA goal that Customer Preparation Processing P100 latency be lower than the
+specified value.  Setting any SLA goal to a non-zero value causes Extremem to search for a maximum transaction rate that
+satisfies the targeted latency constraint.  If multiple non-zero SLA goals are specified, the search for maximum transaction
+rate finds the maximum rate that satisfies all of the non-zero constraints.  The search begins by running the simulation
+specified by other command-line configuration parameters.  It proceeds by making adjustments to CustomerPeriod and
+CustomerThinkTime in increments of 10% of the current value of each, searching for a maximum rate that satisfies the
+SLA constraints.  Once this maximum rate is found, we test 3 additional higher transaction rates in increments of 2.5% of
+the current values of CustomerPeriod and CustomerThinkTime to refine the report of maximum transaction rate.
+Each transaction rate is given two opportunities to succeed before that rate is denoted a failure.
+
 ### *-dKeywordSearchCount=5*
 
 Each customer inquiry consists of a string of this many randomly selected words.  Increasing this number results in an increase in the memory allocated during formulation of each customer inquiry and generally results in an increased number of candidate products that match the inquiry.  This in turn results in more transient memory allocation and more effort in deciding between multiple alternative products that match a given decision criteria.

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -22,7 +22,8 @@ public class Bootstrap extends ExtrememThread {
   private MemoryLog _all_threads_accumulator;
   private AbsoluteTime _start_time;
   private AbsoluteTime _end_time;
-
+  private RelativeTime _customer_period;
+  private RelativeTime _customer_think_time;
 
   Bootstrap(Configuration config, long random_seed) {
     super(config, random_seed);
@@ -120,6 +121,10 @@ public class Bootstrap extends ExtrememThread {
     Trace.msg(4, "all_customers established");
 
     for (boolean max_config_found = false; !max_config_found; ) {
+
+      _customer_period = _config.CustomerPeriod();
+      _customer_think_time = _config.CustomerThinkTime();
+
       configure_simulation_threads();
       boolean success = run_one_experiment();
       if (success) {
@@ -180,9 +185,10 @@ public class Bootstrap extends ExtrememThread {
     int bq_no = _config.BrowsingHistoryQueueCount() - 1;
     int sq_no = _config.SalesTransactionQueueCount() - 1;
     for (int i = 0; i < _config.CustomerThreads(); i++) {
-      _customer_threads[i] = new CustomerThread(_config, randomLong(), i, _all_products, _all_customers, _browsing_queues[bq_no],
-                                               _sales_queues[sq_no], _customer_accumulator, _customer_alloc_accumulator,
-                                               _customer_garbage_accumulator);
+      _customer_threads[i] = new CustomerThread(_config, _customer_period, _customer_think_time,
+						randomLong(), i, _all_products, _all_customers, _browsing_queues[bq_no],
+						_sales_queues[sq_no], _customer_accumulator, _customer_alloc_accumulator,
+						_customer_garbage_accumulator);
       if (bq_no-- == 0) {
         bq_no = _config.BrowsingHistoryQueueCount() - 1;
       }
@@ -489,7 +495,7 @@ public class Bootstrap extends ExtrememThread {
     _customer_accumulator.reportPercentiles(this, _config.ReportCSV());
 
     int customer_thread_count = _config.CustomerThreads();
-    RelativeTime customer_period = _config.CustomerPeriod();
+    RelativeTime customer_period = _customer_period;;
     RelativeTime simulation_duration = _config.SimulationDuration();
     int activations_per_thread = (int) simulation_duration.divideBy(customer_period);
     int expected_activations = customer_thread_count * activations_per_thread;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -74,7 +74,14 @@ public class Bootstrap extends ExtrememThread {
             if (retreating_during_search_for_first_success) {
               Report.errout("Found first success at ", s,
                             " TPS after retreating for failures at higher transaction rates.  Take smaller steps forward.");
+              if (_config.ReportCSV()) {
+                Report.output("First success at TPS:, ", s,
+                              ", (after retreating for failures at higher transaction rates -- taking smaller steps forward)");
 
+              } else {
+                Report.output("Found first success at ", s,
+                              " TPS after retreating for failures at higher transaction rates.  Take smaller steps forward.");
+              }
               first_try = true;
               found_top_failure = true;
               searching_for_greater_success = false;
@@ -82,7 +89,14 @@ public class Bootstrap extends ExtrememThread {
               _customer_period = _customer_period.multiplyBy(this, 0.9);
               _customer_think_time = _customer_think_time.multiplyBy(this, 0.9);
             } else {
-              Report.errout("Found first success at ", s, " TPS, searching for higher transaction rate");
+              Report.errout("Found first success at ", s, " TPS, searching for higher transaction rate.");
+              if (_config.ReportCSV()) {
+                Report.output("First success at TPS:, ", s,
+                              ", (taking smaller steps forward)");
+
+              } else {
+                Report.output("Found first success at ", s, " TPS, searching for higher transaction rate.");
+              }
 
               // Decrease transaction rate by 7.5%
               _customer_period = _customer_period.multiplyBy(this, 1.075);
@@ -93,18 +107,35 @@ public class Bootstrap extends ExtrememThread {
             first_try = true;
 	  } else if (first_try) {
             Report.errout("Failed once at ", s, " TPS.  Retry.");
+            if (_config.ReportCSV()) {
+              Report.output("Failed once at TPS:, ", s, ", (retry)");
+            } else {
+              Report.output("Failed once at ", s, " TPS.  Retry.");
+            }
 	    first_try = false;
 	    // try it again
 	  } else {
 	    if (allowed_retries_for_initial_success-- > 0) {
 	      Report.errout("Failed twice at ", s, " TPS, searching for lower transaction rate");
 	      // Decrease transaction rate by 10%
+              if (_config.ReportCSV()) {
+                Report.output("Failed twice at TPS:, ", s, ", (searching for a lower transaction rate)");
+              } else {
+                Report.output("Failed twice at ", s, " TPS, searching for lower transaction rate");
+              }
 	      _customer_period = _customer_period.multiplyBy(this, 1.1);
 	      _customer_think_time = _customer_think_time.multiplyBy(this, 0.9);
 	      first_try = true;
               retreating_during_search_for_first_success = false;
 	    } else {
 	      Report.errout("Failed to find initial success after ", Integer.toString(MaxRetries), " retries.  Giving up.");
+              Report.errout("Last attempted rate: ", s, " TPS");
+              if (_config.ReportCSV()) {
+                Report.output("Giving up after failed at TPS: ", s, " too many failed attempts: ", Integer.toString(MaxRetries));
+              } else {
+	        Report.output("Failed to find initial success after ", Integer.toString(MaxRetries), " retries.  Giving up.");
+                Report.output("Last attempted rate: ", s, " TPS");
+              }
 	      return;
 	    }
 	  }
@@ -116,7 +147,11 @@ public class Bootstrap extends ExtrememThread {
 	  if (success) {
 	    if (searching_for_greater_success) {
 	      Report.errout("Found greater success at ", s, " TPS, search for even higher transaction rate");
-
+              if (_config.ReportCSV()) {
+                Report.output("Found greater success at TPS:, ", s, ", (search for even higher transaction rate)");
+              } else {
+                Report.output("Found greater success at ", s, " TPS, search for even higher transaction rate");
+              }
 	      // increase transaction rate by 10%.
 	      _customer_period = _customer_period.multiplyBy(this, 0.9);
 	      _customer_think_time = _customer_think_time.multiplyBy(this, 0.9);
@@ -125,16 +160,32 @@ public class Bootstrap extends ExtrememThread {
 	      first_try = true;
 	    } else {
 	      Report.errout("Found greater success at ", s, " TPS.  This is maximum successful rate");
+              if (_config.ReportCSV()) {
+                Report.output("Found greater success at TPS:, ", s, ", (this is maximum successful rate)");
+              } else {
+                Report.output("Found greater success at ", s, " TPS.  This is maximum successful rate");
+              }
 	      return;
 	    }
 	  } else if (first_try) {
             Report.errout("Failed once at ", s, " TPS.  Retry.");
+            if (_config.ReportCSV()) {
+              Report.output("Failed once at TPS: ,", s, ", (retry)");
+            } else {
+              Report.output("Failed once at ", s, " TPS.  Retry.");
+            }
 	    first_try = false;
 	    // try it again
 	  } else if (searching_for_greater_success) {
 	    Report.errout("Failed twice at ", s,
                           " TPS while searching for higher transaction rate.  Take smaller steps backward.");
-
+            if (_config.ReportCSV()) {
+              Report.output("Failed twice at TPS: ,", s,
+                            ", (while searching for higher transaction rate -- taking smaller steps backward)");
+            } else {
+              Report.output("Failed twice at ", s,
+                            " TPS while searching for higher transaction rate.  Take smaller steps backward.");
+            }
 	    // Decrease transaction rate by 2.5%
 	    _customer_period = _customer_period.multiplyBy(this, 1.025);
 	    _customer_think_time = _customer_think_time.multiplyBy(this, 1.025);
@@ -143,11 +194,26 @@ public class Bootstrap extends ExtrememThread {
 	    searching_for_greater_success = false;
 	    search_backward_increments = 0;
 	  } else if (search_backward_increments >= 3) {
-              Report.errout("Search for greater success terminated.  Most recent success is best available.");
+            Report.errout("Failed twice at ", s,
+                          ".  Small-step search for greater success terminated.  Most recent success is best available.");
+            if (_config.ReportCSV()) {
+              Report.output("Failed twice at TPS: ,", s,
+                            ", (in small-step searching for higher transaction rate -- most recent success is best available)");
+            } else {
+              Report.output("Failed twice at ", s,
+                            ".  Small-step search for greater success terminated.  Most recent success is best available.");
+            }
 	    return;
 	  } else {
 	    Report.errout("Failed twice at ", s,
                           " TPS while taking small steps backward.  Try another small step backward.");
+            if (_config.ReportCSV()) {
+              Report.output("Failed twice at TPS: ,", s,
+                            ", (in small-step searching for higher transaction rate -- try another small step backward)");
+            } else {
+              Report.output("Failed twice at ", s,
+                            " TPS while taking small steps backward.  Try another small step backward.");
+            }
 	    // Decrease transaction rate by 2.5%
 	    _customer_period = _customer_period.multiplyBy(this, 1.025);
 	    _customer_think_time = _customer_think_time.multiplyBy(this, 1.025);
@@ -600,9 +666,13 @@ public class Bootstrap extends ExtrememThread {
       Report.output(judgement);
       Report.output("Observed Customer Transactions, Expected Customer Transactions");
       Report.output(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations));
+      Report.errout("Observed Customer Transactions, Expected Customer Transactions");
+      Report.errout(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations));
     } else {
       Report.output(judgement, "observed ", String.valueOf(actual_activations),
-		      " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
+                    " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
+      Report.errout(judgement, "observed ", String.valueOf(actual_activations),
+                    " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
     }
     Report.output();
     Report.releaseReportLock();
@@ -611,7 +681,13 @@ public class Bootstrap extends ExtrememThread {
     if (p50_goal > 0) {
       long p50_actual = _customer_accumulator.getPreparationResponseTimes().getP50();
       if (p50_actual > p50_goal) {
-        Report.output("Failed p50 test: ", String.valueOf(p50_actual), " us > goal: ", String.valueOf(p50_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p50 test because measured us:, ", String.valueOf(p50_actual),
+                        ", greater than goal us:, ", String.valueOf(p50_goal));
+        } else {
+          Report.output("Failed p50 test: ", String.valueOf(p50_actual), " us > goal: ", String.valueOf(p50_goal), " us");
+        }
+        Report.errout("Failed p50 test: ", String.valueOf(p50_actual), " us > goal: ", String.valueOf(p50_goal), " us");
         result = false;
       }
     }
@@ -620,7 +696,13 @@ public class Bootstrap extends ExtrememThread {
     if (p95_goal > 0) {
       long p95_actual = _customer_accumulator.getPreparationResponseTimes().getP95();
       if (p95_actual > p95_goal) {
-        Report.output("Failed p95 test: ", String.valueOf(p95_actual), " us > goal: ", String.valueOf(p95_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p95 test because measured us:, ", String.valueOf(p95_actual),
+                        ", greater than goal us:, ", String.valueOf(p95_goal));
+        } else {
+          Report.output("Failed p95 test: ", String.valueOf(p95_actual), " us > goal: ", String.valueOf(p95_goal), " us");
+        }
+        Report.errout("Failed p95 test: ", String.valueOf(p95_actual), " us > goal: ", String.valueOf(p95_goal), " us");
         result = false;
       }
     }
@@ -629,7 +711,13 @@ public class Bootstrap extends ExtrememThread {
     if (p99_goal > 0) {
       long p99_actual = _customer_accumulator.getPreparationResponseTimes().getP99();
       if (p99_actual > p99_goal) {
-        Report.output("Failed p99 test: ", String.valueOf(p99_actual), " us > goal: ", String.valueOf(p99_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p99 test because measured us:, ", String.valueOf(p99_actual),
+                        ", greater than goal us:, ", String.valueOf(p99_goal));
+        } else {
+          Report.output("Failed p99 test: ", String.valueOf(p99_actual), " us > goal: ", String.valueOf(p99_goal), " us");
+        }
+        Report.errout("Failed p99 test: ", String.valueOf(p99_actual), " us > goal: ", String.valueOf(p99_goal), " us");
         result = false;
       }
     }
@@ -638,7 +726,13 @@ public class Bootstrap extends ExtrememThread {
     if (p99_9_goal > 0) {
       long p99_9_actual = _customer_accumulator.getPreparationResponseTimes().getP99_9();
       if (p99_9_actual > p99_9_goal) {
-        Report.output("Failed p99_9 test: ", String.valueOf(p99_9_actual), " us > goal: ", String.valueOf(p99_9_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p99_9 test because measured us:, ", String.valueOf(p99_9_actual),
+                        ", greater than goal us:, ", String.valueOf(p99_9_goal));
+        } else {
+          Report.output("Failed p99_9 test: ", String.valueOf(p99_9_actual), " us > goal: ", String.valueOf(p99_9_goal), " us");
+        }
+        Report.errout("Failed p99_9 test: ", String.valueOf(p99_9_actual), " us > goal: ", String.valueOf(p99_9_goal), " us");
         result = false;
       }
     }
@@ -647,7 +741,13 @@ public class Bootstrap extends ExtrememThread {
     if (p99_99_goal > 0) {
       long p99_99_actual = _customer_accumulator.getPreparationResponseTimes().getP99_99();
       if (p99_99_actual > p99_99_goal) {
-        Report.output("Failed p99_99 test: ", String.valueOf(p99_99_actual), " us > goal: ", String.valueOf(p99_99_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p99_99 test because measured us:, ", String.valueOf(p99_99_actual),
+                        ", greater than goal us:, ", String.valueOf(p99_99_goal));
+        } else {
+          Report.output("Failed p99_99 test: ", String.valueOf(p99_99_actual), " us > goal: ", String.valueOf(p99_99_goal), " us");
+        }
+        Report.errout("Failed p99_99 test: ", String.valueOf(p99_99_actual), " us > goal: ", String.valueOf(p99_99_goal), " us");
         result = false;
       }
     }
@@ -656,7 +756,14 @@ public class Bootstrap extends ExtrememThread {
     if (p99_999_goal > 0) {
       long p99_999_actual = _customer_accumulator.getPreparationResponseTimes().getP99_999();
       if (p99_999_actual > p99_999_goal) {
-        Report.output("Failed p99_999 test: ", String.valueOf(p99_999_actual),
+        if (_config.ReportCSV()) {
+          Report.output("Failed p99_999 test because measured us:, ", String.valueOf(p99_999_actual),
+                        ", greater than goal us:, ", String.valueOf(p99_999_goal));
+        } else {
+          Report.output("Failed p99_999 test: ", String.valueOf(p99_999_actual),
+                        " us > goal: ", String.valueOf(p99_999_goal), " us");
+        }
+        Report.errout("Failed p99_999 test: ", String.valueOf(p99_999_actual),
 		      " us > goal: ", String.valueOf(p99_999_goal), " us");
         result = false;
       }
@@ -666,7 +773,13 @@ public class Bootstrap extends ExtrememThread {
     if (p100_goal > 0) {
       long p100_actual = _customer_accumulator.getPreparationResponseTimes().getP100();
       if (p100_actual > p100_goal) {
-        Report.output("Failed p100 test: ", String.valueOf(p100_actual), " us > goal: ", String.valueOf(p100_goal), " us");
+        if (_config.ReportCSV()) {
+          Report.output("Failed p100 test because measured us:, ", String.valueOf(p100_actual),
+                        ", greater than goal us:, ", String.valueOf(p100_goal));
+        } else {
+          Report.output("Failed p100 test: ", String.valueOf(p100_actual), " us > goal: ", String.valueOf(p100_goal), " us");
+        }
+        Report.errout("Failed p100 test: ", String.valueOf(p100_actual), " us > goal: ", String.valueOf(p100_goal), " us");
         result = false;
       }
     }

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -5,121 +5,145 @@ package com.amazon.corretto.benchmark.extremem;
 
 public class Bootstrap extends ExtrememThread {
   private static final long NanosPerSecond = 1000000000L;
+  private Configuration _config;
+  private UpdateThread _update_thread;
+  private CustomerThread[] _customer_threads;
+  private ServerThread[] _server_threads;
+  private Products _all_products;
+  private Customers _all_customers;
+  private CustomerLogAccumulator _customer_accumulator;
+  private ServerLogAccumulator _server_accumulator;
+  private MemoryLog _customer_alloc_accumulator, _customer_garbage_accumulator;
+  private MemoryLog _server_alloc_accumulator, _server_garbage_accumulator;
+  private BrowsingHistoryQueue[] _browsing_queues;
+  private SalesTransactionQueue[] _sales_queues;
+  private MemoryLog _memory;
+  private MemoryLog _garbage;
+  private MemoryLog _all_threads_accumulator;
+  private AbsoluteTime _start_time;
+  private AbsoluteTime _end_time;
+
 
   Bootstrap(Configuration config, long random_seed) {
     super(config, random_seed);
     this.setLabel("Bootstrap");
+    _config = config;
+    
   }
 
   public void runExtreme() {
-    UpdateThread update_thread;
-    CustomerThread[] customer_threads;
-    ServerThread[] server_threads;
-
-    RelativeTime customer_stagger = null;
-    RelativeTime server_stagger = null;
 
     // Memory accounting: I have no more fields than parent class
     // ExtrememThread.  So my memory usage is accounted for during my
     // construction.
       
-    MemoryLog memory = memoryLog();
-    MemoryLog garbage = garbageLog();
-    MemoryLog all_threads_accumulator = new MemoryLog(LifeSpan.NearlyForever);
-    all_threads_accumulator.memoryFootprint(this);
+    _memory = memoryLog();
+    _garbage = garbageLog();
+    _all_threads_accumulator = new MemoryLog(LifeSpan.NearlyForever);
+    _all_threads_accumulator.memoryFootprint(this);
       
     Trace.msg(1, "@ ",
-              Integer.toString(memory.hashCode()),
+              Integer.toString(_memory.hashCode()),
               ": Bootstrap.memoryLog()");
     Trace.msg(1, "@ ",
-              Integer.toString(garbage.hashCode()),
+              Integer.toString(_garbage.hashCode()),
               ": Bootstrap.garbageLog()");
-    Trace.msg(1, "@ ", Integer.toString(all_threads_accumulator.hashCode()),
-              ": Bootstrap.all_threads_accumulator");
+    Trace.msg(1, "@ ", Integer.toString(_all_threads_accumulator.hashCode()),
+              ": Bootstrap._all_threads_accumulator");
       
     // config.initialize() replaces the random number generation seed
     // of this before generating the dictionary.
-    config.initialize(this);
-    if (config.ReportCSV()) {
+    _config.initialize(this);
+    if (_config.ReportCSV()) {
       Report.output("All times reported in microseconds");
-      config.dumpCSV(this);
+      _config.dumpCSV(this);
     }
     else
-      config.dump(this);
+      _config.dump(this);
       
-    CustomerLogAccumulator customer_accumulator;
-    ServerLogAccumulator server_accumulator;
-    MemoryLog customer_alloc_accumulator, customer_garbage_accumulator;
-    MemoryLog server_alloc_accumulator, server_garbage_accumulator;
-    customer_accumulator = new CustomerLogAccumulator(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements());
-    server_accumulator = new ServerLogAccumulator(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements());
+    _customer_accumulator = new CustomerLogAccumulator(this, LifeSpan.NearlyForever, _config.ResponseTimeMeasurements());
+    _server_accumulator = new ServerLogAccumulator(this, LifeSpan.NearlyForever, _config.ResponseTimeMeasurements());
 
-    if (!config.ReportIndividualThreads()) {
-      customer_alloc_accumulator = new MemoryLog(LifeSpan.NearlyForever);
-      customer_alloc_accumulator.memoryFootprint(this);
+    if (!_config.ReportIndividualThreads()) {
+      _customer_alloc_accumulator = new MemoryLog(LifeSpan.NearlyForever);
+      _customer_alloc_accumulator.memoryFootprint(this);
 
       Trace.msg(1, "@ ",
-                Integer.toString(customer_alloc_accumulator.hashCode()),
-                ": Bootstrap.customer_alloc_accumulator");
+                Integer.toString(_customer_alloc_accumulator.hashCode()),
+                ": Bootstrap._customer_alloc_accumulator");
 
-      customer_garbage_accumulator = new MemoryLog(LifeSpan.NearlyForever);
-      customer_garbage_accumulator.memoryFootprint(this);
+      _customer_garbage_accumulator = new MemoryLog(LifeSpan.NearlyForever);
+      _customer_garbage_accumulator.memoryFootprint(this);
       
       Trace.msg(1, "@ ",
-                Integer.toString(customer_garbage_accumulator.hashCode()),
-                ": Bootstrap.customer_garbage_accumulator");
+                Integer.toString(_customer_garbage_accumulator.hashCode()),
+                ": Bootstrap._customer_garbage_accumulator");
 
-      server_alloc_accumulator = new MemoryLog(LifeSpan.NearlyForever);
-      server_alloc_accumulator.memoryFootprint(this);
-
-      Trace.msg(1, "@ ",
-                Integer.toString(server_alloc_accumulator.hashCode()),
-                ": Bootstrap.server_alloc_accumulator");
-
-      server_garbage_accumulator = new MemoryLog(LifeSpan.NearlyForever);
-      server_garbage_accumulator.memoryFootprint(this);
+      _server_alloc_accumulator = new MemoryLog(LifeSpan.NearlyForever);
+      _server_alloc_accumulator.memoryFootprint(this);
 
       Trace.msg(1, "@ ",
-                Integer.toString(server_garbage_accumulator.hashCode()),
+                Integer.toString(_server_alloc_accumulator.hashCode()),
+                ": Bootstrap._server_alloc_accumulator");
+
+      _server_garbage_accumulator = new MemoryLog(LifeSpan.NearlyForever);
+      _server_garbage_accumulator.memoryFootprint(this);
+
+      Trace.msg(1, "@ ",
+                Integer.toString(_server_garbage_accumulator.hashCode()),
                 ": Bootstrap.server_garbage__accumulator");
     } else {
-      customer_alloc_accumulator = null;
-      customer_garbage_accumulator = null;
-      server_alloc_accumulator = null;
-      server_garbage_accumulator = null;
+      _customer_alloc_accumulator = null;
+      _customer_garbage_accumulator = null;
+      _server_alloc_accumulator = null;
+      _server_garbage_accumulator = null;
     }
       
-    SalesTransactionQueue[] sales_queues = (
-      new SalesTransactionQueue[config.SalesTransactionQueueCount()]);
+    _sales_queues = new SalesTransactionQueue[_config.SalesTransactionQueueCount()];
     Util.referenceArray(this, LifeSpan.NearlyForever,
-                        config.SalesTransactionQueueCount());
-    for (int i = 0; i < config.SalesTransactionQueueCount(); i++)
-      sales_queues[i] = new SalesTransactionQueue(this,
+                        _config.SalesTransactionQueueCount());
+    for (int i = 0; i < _config.SalesTransactionQueueCount(); i++)
+      _sales_queues[i] = new SalesTransactionQueue(this,
                                                   LifeSpan.NearlyForever);
-    BrowsingHistoryQueue[] browsing_queues = (
-      new BrowsingHistoryQueue[config.BrowsingHistoryQueueCount()]);
+    _browsing_queues = new BrowsingHistoryQueue[_config.BrowsingHistoryQueueCount()];
     Util.referenceArray(this, LifeSpan.NearlyForever,
-                        config.BrowsingHistoryQueueCount());
-    for (int i = 0; i < config.BrowsingHistoryQueueCount(); i++)
-      browsing_queues[i] = new BrowsingHistoryQueue(this,
+                        _config.BrowsingHistoryQueueCount());
+    for (int i = 0; i < _config.BrowsingHistoryQueueCount(); i++)
+      _browsing_queues[i] = new BrowsingHistoryQueue(this,
                                                     LifeSpan.NearlyForever);
-    Trace.msg(4, "browsing_queues and sales_queues established");
+    Trace.msg(4, "_browsing_queues and _sales_queues established");
       
-    Products all_products = (
-      new Products(this, LifeSpan.NearlyForever, config));
+    _all_products = new Products(this, LifeSpan.NearlyForever, _config);
     Trace.msg(4, "all_products established");
-    Customers all_customers = new Customers(this, LifeSpan.NearlyForever,
-                                            config);
+
+    _all_customers = new Customers(this, LifeSpan.NearlyForever, _config);
     Trace.msg(4, "all_customers established");
+
+    for (boolean max_config_found = false; !max_config_found; ) {
+      configure_simulation_threads();
+      boolean success = run_one_experiment();
+      if (success) {
+        Report.output("Simulation was successful");
+      } else {
+        Report.output("Simulation failed");
+      }
+      // first pass, keep it simple
+      max_config_found = true;
+    }
+  }
+
+  public void configure_simulation_threads() {
+    RelativeTime customer_stagger = null;
+    RelativeTime server_stagger = null;
       
-    if (config.CustomerThreads() > 0) {
+    if (_config.CustomerThreads() > 0) {
       // Stagger the Customer threads so they are not all triggered at
       // the same moment in time.
-      RelativeTime period = config.CustomerPeriod();
+      RelativeTime period = _config.CustomerPeriod();
       long period_ns = (
         period.nanoseconds() +
-        (config.CustomerPeriod().seconds() * NanosPerSecond));
-      long stagger = period_ns / config.CustomerThreads();
+        (_config.CustomerPeriod().seconds() * NanosPerSecond));
+      long stagger = period_ns / _config.CustomerThreads();
       customer_stagger = new RelativeTime(this, stagger / NanosPerSecond,
                                           (int) (stagger % NanosPerSecond));
       Trace.msg(3, "Customer stagger set to: ",
@@ -128,100 +152,99 @@ public class Bootstrap extends ExtrememThread {
       
     RelativeTime customer_replacement_stagger = null;
     RelativeTime product_replacement_stagger = null;
-      
-    if (config.ServerThreads() > 0) {
+    if (_config.ServerThreads() > 0) {
       // Stagger the Server threads so they are not all triggered at the
       // same moment in time.
-      RelativeTime period = config.ServerPeriod();
+      RelativeTime period = _config.ServerPeriod();
       long period_ns = (period.nanoseconds() +
-                        (config.ServerPeriod().seconds() * NanosPerSecond));
-      long stagger = period_ns / config.ServerThreads();
+                        (_config.ServerPeriod().seconds() * NanosPerSecond));
+      long stagger = period_ns / _config.ServerThreads();
       server_stagger = new RelativeTime(this, stagger / NanosPerSecond,
                                         (int) (stagger % NanosPerSecond));
       customer_replacement_stagger = (
-        config.CustomerReplacementPeriod().divideBy(this,
-                                                    config.ServerThreads()));
+        _config.CustomerReplacementPeriod().divideBy(this,
+                                                    _config.ServerThreads()));
       product_replacement_stagger = (
-        config.ProductReplacementPeriod().divideBy(this,
-                                                   config.ServerThreads()));
+        _config.ProductReplacementPeriod().divideBy(this,
+                                                   _config.ServerThreads()));
       Trace.msg(3, "Server stagger set to: ", server_stagger.toString(this));
     }
       
-    Trace.msg(2, "starting up CustomerThreads: ", Integer.toString(config.CustomerThreads()));
+    Trace.msg(2, "starting up CustomerThreads: ", Integer.toString(_config.CustomerThreads()));
       
     // Initialize and startup all of the threads as specified in
-    // config.
-    customer_threads = new CustomerThread[config.CustomerThreads()];
-    Util.referenceArray(this, LifeSpan.NearlyForever, config.CustomerThreads());
+    // _config.
+    _customer_threads = new CustomerThread[_config.CustomerThreads()];
+    Util.referenceArray(this, LifeSpan.NearlyForever, _config.CustomerThreads());
       
-    int bq_no = config.BrowsingHistoryQueueCount() - 1;
-    int sq_no = config.SalesTransactionQueueCount() - 1;
-    for (int i = 0; i < config.CustomerThreads(); i++) {
-      customer_threads[i] = new CustomerThread(config, randomLong(), i, all_products, all_customers, browsing_queues[bq_no],
-                                               sales_queues[sq_no], customer_accumulator, customer_alloc_accumulator,
-                                               customer_garbage_accumulator);
+    int bq_no = _config.BrowsingHistoryQueueCount() - 1;
+    int sq_no = _config.SalesTransactionQueueCount() - 1;
+    for (int i = 0; i < _config.CustomerThreads(); i++) {
+      _customer_threads[i] = new CustomerThread(_config, randomLong(), i, _all_products, _all_customers, _browsing_queues[bq_no],
+                                               _sales_queues[sq_no], _customer_accumulator, _customer_alloc_accumulator,
+                                               _customer_garbage_accumulator);
       if (bq_no-- == 0) {
-        bq_no = config.BrowsingHistoryQueueCount() - 1;
+        bq_no = _config.BrowsingHistoryQueueCount() - 1;
       }
       if (sq_no-- == 0) {
-        sq_no = config.SalesTransactionQueueCount() - 1;
+        sq_no = _config.SalesTransactionQueueCount() - 1;
       }
     }
     if (customer_stagger != null) {
       customer_stagger.garbageFootprint(this);
     }
     Trace.msg(2, "starting up ServerThreads: ",
-              Integer.toString(config.ServerThreads()));
+              Integer.toString(_config.ServerThreads()));
       
-    server_threads = new ServerThread[config.ServerThreads()];
-    Util.referenceArray(this, LifeSpan.NearlyForever, config.ServerThreads());
+    _server_threads = new ServerThread[_config.ServerThreads()];
+    Util.referenceArray(this, LifeSpan.NearlyForever, _config.ServerThreads());
       
-    bq_no = config.BrowsingHistoryQueueCount() - 1;
-    sq_no = config.SalesTransactionQueueCount() - 1;
-    for (int i = 0; i < config.ServerThreads(); i++) {
-      server_threads[i] = new ServerThread(config, randomLong(), i, all_products, all_customers, browsing_queues[bq_no],
-                                           sales_queues[sq_no], server_accumulator, server_alloc_accumulator,
-                                           server_garbage_accumulator);
+    bq_no = _config.BrowsingHistoryQueueCount() - 1;
+    sq_no = _config.SalesTransactionQueueCount() - 1;
+    for (int i = 0; i < _config.ServerThreads(); i++) {
+      _server_threads[i] = new ServerThread(_config, randomLong(), i, _all_products, _all_customers, _browsing_queues[bq_no],
+                                           _sales_queues[sq_no], _server_accumulator, _server_alloc_accumulator,
+                                           _server_garbage_accumulator);
       if (bq_no-- == 0)
-        bq_no = config.BrowsingHistoryQueueCount() - 1;
+        bq_no = _config.BrowsingHistoryQueueCount() - 1;
       if (sq_no-- == 0)
-        sq_no = config.SalesTransactionQueueCount() - 1;
+        sq_no = _config.SalesTransactionQueueCount() - 1;
     }
     
-    if (config.PhasedUpdates()) {
-      update_thread = new UpdateThread(config, randomLong(), all_products, all_customers);
+    if (_config.PhasedUpdates()) {
+      _update_thread = new UpdateThread(_config, randomLong(), _all_products, _all_customers);
     } else {
-      update_thread = null;
+      _update_thread = null;
     }
   
     AbsoluteTime now = AbsoluteTime.now(this);
 
     // Add 4 ms to conservatively approximate the time required to establish start times and start() each thread
-    AbsoluteTime start_time = now.addMillis(this, 4 * (config.CustomerThreads() + config.ServerThreads()));
-    AbsoluteTime end_time =  start_time.addRelative(this, config.SimulationDuration());
+    _start_time = now.addMillis(this, 4 * (_config.CustomerThreads() + _config.ServerThreads()));
+     _end_time =  _start_time.addRelative(this, _config.SimulationDuration());
 
-    AbsoluteTime staggered_customer_replacement = new AbsoluteTime(this, start_time);
-    AbsoluteTime staggered_product_replacement = new AbsoluteTime(this, start_time);
+    AbsoluteTime staggered_customer_replacement = new AbsoluteTime(this, _start_time);
+    AbsoluteTime staggered_product_replacement = new AbsoluteTime(this, _start_time);
 
     String s;
-    if (config.ReportCSV()) {
-      s = Long.toString(start_time.microseconds());
+    if (_config.ReportCSV()) {
+      s = Long.toString(_start_time.microseconds());
       Util.ephemeralString(this, s.length());
       Report.output("Simulation start time,", s);
     } else {
-      s = start_time.toString(this);
+      s = _start_time.toString(this);
       Report.output("  Simulation starts: ", s);
     }
     Trace.msg(2, "");
     Trace.msg(2, "  Simulation starts: ", s);
     Util.abandonEphemeralString(this, s);
       
-    if (config.ReportCSV()) {
-      s = Long.toString(end_time.microseconds());
+    if (_config.ReportCSV()) {
+      s = Long.toString(_end_time.microseconds());
       Util.ephemeralString(this, s.length());
       Report.output("Simulation end time,", s);
     } else {
-      s = end_time.toString(this);
+      s = _end_time.toString(this);
       Report.output("End simulation time: ", s);
     }
     Trace.msg(2, "End simulation time: ", s);
@@ -229,26 +252,26 @@ public class Bootstrap extends ExtrememThread {
     Util.abandonEphemeralString(this, s);
 
     // startup the customer threads
-    AbsoluteTime staggered_start = start_time.addMinutes(this, 0);
-    for (int i = 0; i < config.CustomerThreads(); i++) {
-      customer_threads[i].setStartAndStop(staggered_start, end_time);
+    AbsoluteTime staggered_start = _start_time.addMinutes(this, 0);
+    for (int i = 0; i < _config.CustomerThreads(); i++) {
+      _customer_threads[i].setStartAndStop(staggered_start, _end_time);
       staggered_start.garbageFootprint(this);
-      customer_threads[i].start(); // will wait for first release
+      _customer_threads[i].start(); // will wait for first release
       staggered_start = staggered_start.addRelative(this, customer_stagger);
     }
 
     // startup the server threads
-    staggered_start = start_time.addMinutes(this, 0);
-    for (int i = 0; i < config.ServerThreads(); i++) {
-      server_threads[i].setStartsAndStop(staggered_start, staggered_customer_replacement, staggered_product_replacement,
-                                         end_time);
+    staggered_start = _start_time.addMinutes(this, 0);
+    for (int i = 0; i < _config.ServerThreads(); i++) {
+      _server_threads[i].setStartsAndStop(staggered_start, staggered_customer_replacement, staggered_product_replacement,
+                                         _end_time);
       staggered_start.garbageFootprint(this);
       staggered_start = staggered_start.addRelative(this, server_stagger);
       staggered_customer_replacement.garbageFootprint(this);
       staggered_customer_replacement = staggered_customer_replacement.addRelative(this, customer_replacement_stagger);
       staggered_product_replacement.garbageFootprint(this);
       staggered_product_replacement = staggered_product_replacement.addRelative(this, product_replacement_stagger);
-      server_threads[i].start(); // will wait for first release
+      _server_threads[i].start(); // will wait for first release
     }
 
     staggered_start.garbageFootprint(this);
@@ -260,27 +283,30 @@ public class Bootstrap extends ExtrememThread {
     staggered_product_replacement.garbageFootprint(this);
     staggered_product_replacement = null;
 
-    if (server_stagger != null)
+    if (server_stagger != null) {
       server_stagger.garbageFootprint(this);
+    }
       
-    if (customer_replacement_stagger != null)
+    if (customer_replacement_stagger != null) {
       customer_replacement_stagger.garbageFootprint(this);
+    }
     customer_replacement_stagger = null;
       
-    if (product_replacement_stagger != null)
+    if (product_replacement_stagger != null) {
       product_replacement_stagger.garbageFootprint(this);
+    }
     product_replacement_stagger = null;
 
-    if (config.PhasedUpdates()) {
-      staggered_start = start_time.addRelative(this, config.PhasedUpdateInterval());
-      update_thread.setStartAndStop(staggered_start, end_time);
-      update_thread.start();    // will wait for first release
+    if (_config.PhasedUpdates()) {
+      staggered_start = _start_time.addRelative(this, _config.PhasedUpdateInterval());
+      _update_thread.setStartAndStop(staggered_start, _end_time);
+      _update_thread.start();    // will wait for first release
       staggered_start.garbageFootprint(this);
       staggered_start = null;
     }
 
     now = AbsoluteTime.now(this);
-    if (config.ReportCSV()) {
+    if (_config.ReportCSV()) {
       s = Long.toString(now.microseconds());
       Util.ephemeralString(this, s.length());
       Report.output("Initialization completion time,", s);
@@ -291,44 +317,48 @@ public class Bootstrap extends ExtrememThread {
     }
     Util.abandonEphemeralString(this, s);
 
-    if (now.compare(start_time) > 0) {
+    if (now.compare(_start_time) > 0) {
       Report.output("Warning!  Consumed more than 4 ms to start each thread.");
-      s = start_time.toString(this);
+      s = _start_time.toString(this);
       Report.output(" Planned to start at: ", s);
       s = now.toString(this);
       Report.output("Actually starting at: ", s);
     }
-    start_time.garbageFootprint(this);
-    start_time = null;
-    end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
+    _start_time.garbageFootprint(this);
+    _start_time = null;
+    _end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
     now.garbageFootprint(this);
     now = null;
+  }
+
+  // Returns true iff the test was considered successful
+  public boolean run_one_experiment() {
       
     Trace.msg(2, "Joining with customer threads");
-    // Each thread will terminate when the end_time is reached.
-    for (int i = 0; i < config.CustomerThreads(); i++) {
+    // Each thread will terminate when the _end_time is reached.
+    for (int i = 0; i < _config.CustomerThreads(); i++) {
       try {
-        customer_threads[i].join();
+        _customer_threads[i].join();
       } catch (InterruptedException x) {
         i--;                    // just try it again
       }
     }
       
     Trace.msg(2, "Joining with server threads");
-    for (int i = 0; i < config.ServerThreads(); i++) {
+    for (int i = 0; i < _config.ServerThreads(); i++) {
       try {
-        server_threads[i].join();
+        _server_threads[i].join();
       } catch (InterruptedException x) {
         i--;                    // just try it again
       }
     }
 
-    if (update_thread != null) {
+    if (_update_thread != null) {
       Trace.msg(2, "Joining with update thread");
       boolean retry = false;
       do {
         try {
-          update_thread.join();
+          _update_thread.join();
           retry = false;
         } catch (InterruptedException x) {
           retry = true;
@@ -337,151 +367,221 @@ public class Bootstrap extends ExtrememThread {
     }
 
     Trace.msg(2, "Program simulation has ended");
-    all_products.report(this);
-    all_customers.report(this);
-    if (!config.ReportIndividualThreads()) {
+    _all_products.report(this);
+    _all_customers.report(this);
+    if (!_config.ReportIndividualThreads()) {
         
       Report.acquireReportLock();
-      customer_accumulator.report(this, "(all customer threads)",
-                                  config.ReportCSV());
-      MemoryLog.report(this, config.ReportCSV(), customer_alloc_accumulator,
-                       customer_garbage_accumulator);
+      _customer_accumulator.report(this, "(all customer threads)",
+                                  _config.ReportCSV());
+      MemoryLog.report(this, _config.ReportCSV(), _customer_alloc_accumulator,
+                       _customer_garbage_accumulator);
         
       Report.output("");
       Report.output("Bootstrap thread after reporting customer accumulator");
-      MemoryLog.report(this, config.ReportCSV(), memory, garbage);
+      MemoryLog.report(this, _config.ReportCSV(), _memory, _garbage);
         
-      server_accumulator.report(this, "(all server threads)",
-                                config.ReportCSV());
-      MemoryLog.report(this, config.ReportCSV(), server_alloc_accumulator,
-                       server_garbage_accumulator);
+      _server_accumulator.report(this, "(all server threads)",
+                                _config.ReportCSV());
+      MemoryLog.report(this, _config.ReportCSV(), _server_alloc_accumulator,
+                       _server_garbage_accumulator);
         
-      customer_alloc_accumulator.foldInto(server_alloc_accumulator);
-      customer_alloc_accumulator.foldOutof(customer_garbage_accumulator);
-      customer_alloc_accumulator.foldOutof(server_garbage_accumulator);
+      _customer_alloc_accumulator.foldInto(_server_alloc_accumulator);
+      _customer_alloc_accumulator.foldOutof(_customer_garbage_accumulator);
+      _customer_alloc_accumulator.foldOutof(_server_garbage_accumulator);
         
-      all_threads_accumulator.foldInto(customer_alloc_accumulator);
+      _all_threads_accumulator.foldInto(_customer_alloc_accumulator);
         
       Report.output();
       Report.output("Customer/Server thread Net Allocation (expect zero)");
-      MemoryLog.reportCumulative(this, config.ReportCSV(),
-                                 customer_alloc_accumulator);
+      MemoryLog.reportCumulative(this, _config.ReportCSV(),
+                                 _customer_alloc_accumulator);
 
       Report.releaseReportLock();
     } else {
       // Individual threads have printed their individual reports.
-      for (int i = 0; i < config.CustomerThreads(); i++) {
-        all_threads_accumulator.foldInto(customer_threads[i].memoryLog());
-        all_threads_accumulator.foldOutof(customer_threads[i].garbageLog());
+      for (int i = 0; i < _config.CustomerThreads(); i++) {
+        _all_threads_accumulator.foldInto(_customer_threads[i].memoryLog());
+        _all_threads_accumulator.foldOutof(_customer_threads[i].garbageLog());
       }
-      for (int i = 0; i < config.ServerThreads(); i++) {
-        all_threads_accumulator.foldInto(server_threads[i].memoryLog());
-        all_threads_accumulator.foldOutof(server_threads[i].garbageLog());
+      for (int i = 0; i < _config.ServerThreads(); i++) {
+        _all_threads_accumulator.foldInto(_server_threads[i].memoryLog());
+        _all_threads_accumulator.foldOutof(_server_threads[i].garbageLog());
       }
     }
       
-    for (int i = 0; i < config.ServerThreads(); i++)
-      server_threads[i].garbageFootprint(this);
-    server_threads = null;
+    for (int i = 0; i < _config.ServerThreads(); i++) {
+      _server_threads[i].garbageFootprint(this);
+    }
+    _server_threads = null;
     Util.abandonReferenceArray(this, LifeSpan.NearlyForever,
-                               config.ServerThreads());
+                               _config.ServerThreads());
       
-    for (int i = 0; i < config.CustomerThreads(); i++)
-      customer_threads[i].garbageFootprint(this);
-    customer_threads = null;
+    for (int i = 0; i < _config.CustomerThreads(); i++) {
+      _customer_threads[i].garbageFootprint(this);
+    }
+    _customer_threads = null;
     Util.abandonReferenceArray(this, LifeSpan.NearlyForever,
-                               config.CustomerThreads());
+                               _config.CustomerThreads());
       
-    end_time.garbageFootprint(this);
-    end_time = null;
+    _end_time.garbageFootprint(this);
+    _end_time = null;
       
-    customer_threads = null;
-    server_threads = null;
+    _customer_threads = null;
+    _server_threads = null;
 
-    all_customers.garbageFootprint(this);
-    all_customers = null;
+    _all_customers.garbageFootprint(this);
+    _all_customers = null;
       
-    all_products.garbageFootprint(this);
-    all_products = null;
+    _all_products.garbageFootprint(this);
+    _all_products = null;
       
-    for (int i = 0; i < config.BrowsingHistoryQueueCount(); i++) {
-      browsing_queues[i].garbageFootprint(this);
-      browsing_queues[i] = null;
+    for (int i = 0; i < _config.BrowsingHistoryQueueCount(); i++) {
+      _browsing_queues[i].garbageFootprint(this);
+      _browsing_queues[i] = null;
     }
     Util.abandonReferenceArray(this, LifeSpan.NearlyForever,
-                               config.BrowsingHistoryQueueCount());
-    browsing_queues = null;
+                               _config.BrowsingHistoryQueueCount());
+    _browsing_queues = null;
       
-    for (int i = 0; i < config.SalesTransactionQueueCount(); i++) {
-      sales_queues[i].garbageFootprint(this);
-      sales_queues[i] = null;
+    for (int i = 0; i < _config.SalesTransactionQueueCount(); i++) {
+      _sales_queues[i].garbageFootprint(this);
+      _sales_queues[i] = null;
     }
     Util.abandonReferenceArray(this, LifeSpan.NearlyForever,
-                               config.SalesTransactionQueueCount());
-    sales_queues = null;
+                               _config.SalesTransactionQueueCount());
+    _sales_queues = null;
       
     // While these objects may not be garbage quite yet, treat them as
     // if they were, so that report on net memory allocations balance
     // out to zero.
       
-    if (!config.ReportIndividualThreads()) {
-      server_garbage_accumulator.garbageFootprint(this);
-      server_alloc_accumulator.garbageFootprint(this);
-      customer_garbage_accumulator.garbageFootprint(this);
-      customer_alloc_accumulator.garbageFootprint(this);
+    if (!_config.ReportIndividualThreads()) {
+      _server_garbage_accumulator.garbageFootprint(this);
+      _server_alloc_accumulator.garbageFootprint(this);
+      _customer_garbage_accumulator.garbageFootprint(this);
+      _customer_alloc_accumulator.garbageFootprint(this);
     } 
-    server_accumulator.garbageFootprint(this);
-    customer_accumulator.garbageFootprint(this);
+    _server_accumulator.garbageFootprint(this);
+    _customer_accumulator.garbageFootprint(this);
 
-    config.garbageFootprint(this);
-    all_threads_accumulator.garbageFootprint(this);
+    _config.garbageFootprint(this);
+    _all_threads_accumulator.garbageFootprint(this);
     this.garbageFootprint(this);
       
     // This should be empty
     Report.output("");
     Report.output("Bootstrap thread after discarding this");
-    MemoryLog.report(this, config.ReportCSV(), memory, garbage);
+    MemoryLog.report(this, _config.ReportCSV(), _memory, _garbage);
       
-    all_threads_accumulator.foldInto(memory);
-    all_threads_accumulator.foldOutof(garbage);
+    _all_threads_accumulator.foldInto(_memory);
+    _all_threads_accumulator.foldOutof(_garbage);
     
     Report.acquireReportLock();
     Report.output();
     Report.output("Net allocation for all threads (should be zero)");
-    MemoryLog.reportCumulative(this, config.ReportCSV(),
-                               all_threads_accumulator);
-    all_threads_accumulator = null;
+    MemoryLog.reportCumulative(this, _config.ReportCSV(),
+                               _all_threads_accumulator);
+    _all_threads_accumulator = null;
     Report.releaseReportLock();
 
-    server_accumulator.reportPercentiles(this, config.ReportCSV());
-    customer_accumulator.reportPercentiles(this, config.ReportCSV());
+    _server_accumulator.reportPercentiles(this, _config.ReportCSV());
+    _customer_accumulator.reportPercentiles(this, _config.ReportCSV());
 
-    int customer_thread_count = config.CustomerThreads();
-    RelativeTime customer_period = config.CustomerPeriod();
-    RelativeTime simulation_duration = config.SimulationDuration();
+    int customer_thread_count = _config.CustomerThreads();
+    RelativeTime customer_period = _config.CustomerPeriod();
+    RelativeTime simulation_duration = _config.SimulationDuration();
     int activations_per_thread = (int) simulation_duration.divideBy(customer_period);
     int expected_activations = customer_thread_count * activations_per_thread;
-    int actual_activations = customer_accumulator.engagements();
+    int actual_activations = _customer_accumulator.engagements();
+    boolean result = actual_activations + customer_thread_count >= expected_activations;
 
     Report.acquireReportLock();
     Report.output();
-    if (config.ReportCSV()) {
+    String judgement = result? "Looks good: ": "PROBLEM: ";
+    if (_config.ReportCSV()) {
+      Report.output(judgement);
       Report.output("Observed Customer Transactions, Expected Customer Transactions");
       Report.output(String.valueOf(actual_activations), ", ", String.valueOf(expected_activations));
     } else {
-      String judgement = (actual_activations >= expected_activations)? "Looks good: ": "PROBLEM: ";
       Report.output(judgement, "observed ", String.valueOf(actual_activations),
 		      " customer interactions out of at least ", String.valueOf(expected_activations), " expected transactions");
     }
     Report.output();
     Report.releaseReportLock();
 
-    customer_accumulator = null;
-    customer_alloc_accumulator  = null;
-    customer_garbage_accumulator = null;
-    server_accumulator = null;
-    server_alloc_accumulator = null;
-    server_garbage_accumulator = null;
+    long p50_goal = _config.MaxP50CustomerPrepMicroseconds();
+    if (p50_goal > 0) {
+      long p50_actual = _customer_accumulator.getPreparationResponseTimes().getP50();
+      if (p50_actual > p50_goal) {
+        Report.output("Failed p50 test: ", String.valueOf(p50_actual), " us > goal: ", String.valueOf(p50_goal), " us");
+        result = false;
+      }
+    }
+
+    long p95_goal = _config.MaxP95CustomerPrepMicroseconds();
+    if (p95_goal > 0) {
+      long p95_actual = _customer_accumulator.getPreparationResponseTimes().getP95();
+      if (p95_actual > p95_goal) {
+        Report.output("Failed p95 test: ", String.valueOf(p95_actual), " us > goal: ", String.valueOf(p95_goal), " us");
+        result = false;
+      }
+    }
+
+    long p99_goal = _config.MaxP99CustomerPrepMicroseconds();
+    if (p99_goal > 0) {
+      long p99_actual = _customer_accumulator.getPreparationResponseTimes().getP99();
+      if (p99_actual > p99_goal) {
+        Report.output("Failed p99 test: ", String.valueOf(p99_actual), " us > goal: ", String.valueOf(p99_goal), " us");
+        result = false;
+      }
+    }
+
+    long p99_9_goal = _config.MaxP99_9CustomerPrepMicroseconds();
+    if (p99_9_goal > 0) {
+      long p99_9_actual = _customer_accumulator.getPreparationResponseTimes().getP99_9();
+      if (p99_9_actual > p99_9_goal) {
+        Report.output("Failed p99_9 test: ", String.valueOf(p99_9_actual), " us > goal: ", String.valueOf(p99_9_goal), " us");
+        result = false;
+      }
+    }
+
+    long p99_99_goal = _config.MaxP99_99CustomerPrepMicroseconds();
+    if (p99_99_goal > 0) {
+      long p99_99_actual = _customer_accumulator.getPreparationResponseTimes().getP99_99();
+      if (p99_99_actual > p99_99_goal) {
+        Report.output("Failed p99_99 test: ", String.valueOf(p99_99_actual), " us > goal: ", String.valueOf(p99_99_goal), " us");
+        result = false;
+      }
+    }
+
+    long p99_999_goal = _config.MaxP99_999CustomerPrepMicroseconds();
+    if (p99_999_goal > 0) {
+      long p99_999_actual = _customer_accumulator.getPreparationResponseTimes().getP99_999();
+      if (p99_999_actual > p99_999_goal) {
+        Report.output("Failed p99_999 test: ", String.valueOf(p99_999_actual),
+		      " us > goal: ", String.valueOf(p99_999_goal), " us");
+        result = false;
+      }
+    }
+
+    long p100_goal = _config.MaxP100CustomerPrepMicroseconds();
+    if (p100_goal > 0) {
+      long p100_actual = _customer_accumulator.getPreparationResponseTimes().getP100();
+      if (p100_actual > p100_goal) {
+        Report.output("Failed p100 test: ", String.valueOf(p100_actual), " us > goal: ", String.valueOf(p100_goal), " us");
+        result = false;
+      }
+    }
+
+    _customer_accumulator = null;
+    _customer_alloc_accumulator  = null;
+    _customer_garbage_accumulator = null;
+    _server_accumulator = null;
+    _server_alloc_accumulator = null;
+    _server_garbage_accumulator = null;
+
+    return result;
   }
 
   // No need to override superclass because Bootstrap introduces no

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -50,6 +50,13 @@ class Configuration {
   static final int DefaultProductDescriptionLength = 24;
 
   static final int DefaultMaxArrayLength = 0;
+  static final int DefaultMaxP50CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP95CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP99CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP99_9CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP99_99CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP99_999CustomerPrepMicroseconds = 0;
+  static final int DefaultMaxP100CustomerPrepMicroseconds = 0;
   static final int DefaultNumCustomers = 10000;
   static final int DefaultCustomerThreads = 1440;
   static final int DefaultCustomerPeriodMinutes = 4;
@@ -86,6 +93,13 @@ class Configuration {
   private int DictionarySize;
   private int ResponseTimeMeasurements;
   private int MaxArrayLength;
+  private int MaxP50CustomerPrepMicroseconds;
+  private int MaxP95CustomerPrepMicroseconds;
+  private int MaxP99CustomerPrepMicroseconds;
+  private int MaxP99_9CustomerPrepMicroseconds;
+  private int MaxP99_99CustomerPrepMicroseconds;
+  private int MaxP99_999CustomerPrepMicroseconds;
+  private int MaxP100CustomerPrepMicroseconds;
   private int NumCustomers;
   private int NumProducts;
   private int ProductNameLength;
@@ -163,9 +177,9 @@ class Configuration {
                    Polarity.Expand, 1);
 
     // Account for
-    //  17 int fields: DictionarySize, ResponseTimeMeasurements,
-    //                 MaxArrayLength, NumCustomers,
-    //                 NumProducts, ProductNameLength,
+    //  24 int fields: DictionarySize, ResponseTimeMeasurements,
+    //                 MaxArrayLength, MaxP???CustomerPrepMicroseconds (7 fields),
+    //                 NumCustomers, NumProducts, ProductNameLength,
     //                 ProductDescriptionLength, ProductReviewLength,
     //                 RandomSeed, KeywordSearchCount,
     //                 CustomerThreads, ServerThreads, 
@@ -177,7 +191,7 @@ class Configuration {
     //   2 float fields: BuyThreshold, SaveForLaterThreshold;
     //   2 boolean fields: ReportIndividualThreads, ReportCSV
     log.accumulate(LifeSpan.NearlyForever, MemoryFlavor.ObjectRSB,
-                   Polarity.Expand, 17 * Util.SizeOfInt +
+                   Polarity.Expand, 24 * Util.SizeOfInt +
                    2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
     // Account for 10 reference fields: args, dictionary,
@@ -196,6 +210,13 @@ class Configuration {
                      Polarity.Expand, DictionaryFile.length());
 
     MaxArrayLength = DefaultMaxArrayLength;
+    MaxP50CustomerPrepMicroseconds = DefaultMaxP50CustomerPrepMicroseconds;
+    MaxP95CustomerPrepMicroseconds = DefaultMaxP95CustomerPrepMicroseconds;
+    MaxP99CustomerPrepMicroseconds = DefaultMaxP99CustomerPrepMicroseconds;
+    MaxP99_9CustomerPrepMicroseconds = DefaultMaxP99_9CustomerPrepMicroseconds;
+    MaxP99_99CustomerPrepMicroseconds = DefaultMaxP99_99CustomerPrepMicroseconds;
+    MaxP99_999CustomerPrepMicroseconds = DefaultMaxP99_999CustomerPrepMicroseconds;
+    MaxP100CustomerPrepMicroseconds = DefaultMaxP100CustomerPrepMicroseconds;
     NumCustomers = DefaultNumCustomers;
     NumProducts = DefaultNumProducts;
     ProductNameLength = DefaultProductNameLength;
@@ -272,6 +293,13 @@ class Configuration {
     "DictionarySize",
     "KeywordSearchCount",
     "MaxArrayLength",
+    "MaxP50CustomerPrepMicroseconds",
+    "MaxP95CustomerPrepMicroseconds",
+    "MaxP99CustomerPrepMicroseconds",
+    "MaxP99_9CustomerPrepMicroseconds",
+    "MaxP99_99CustomerPrepMicroseconds",
+    "MaxP99_999CustomerPrepMicroseconds",
+    "MaxP100CustomerPrepMicroseconds",
     "NumCustomers",
     "NumProducts",
     "ProductDescriptionLength",
@@ -427,56 +455,91 @@ class Configuration {
           break;
         }
       case 6:
+        if (keyword.equals("MaxP50CustomerPrepMicroseconds")) {
+          MaxP50CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 7:
+        if (keyword.equals("MaxP95CustomerPrepMicroseconds")) {
+          MaxP95CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 8:
+        if (keyword.equals("MaxP99CustomerPrepMicroseconds")) {
+          MaxP99CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 9:
+        if (keyword.equals("MaxP99_9CustomerPrepMicroseconds")) {
+          MaxP99_9CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 10:
+        if (keyword.equals("MaxP99_99CustomerPrepMicroseconds")) {
+          MaxP99_99CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 11:
+        if (keyword.equals("MaxP99_999CustomerPrepMicroseconds")) {
+          MaxP99_999CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 12:
+        if (keyword.equals("MaxP100CustomerPrepMicroseconds")) {
+          MaxP100CustomerPrepMicroseconds = u;
+          break;
+        }
+      case 13:
         if (keyword.equals("NumCustomers")) {
           NumCustomers = u;
           break;
         }
-      case 7:
+      case 14:
         if (keyword.equals("NumProducts")) {
           NumProducts = u;
           break;
         }
-      case 8:
+      case 15:
         if (keyword.equals("ProductDescriptionLength")) {
           ProductDescriptionLength = u;
           break;
         }
-      case 9:
+      case 16:
         if (keyword.equals("ProductNameLength")) {
           ProductNameLength = u;
           break;
         }
-      case 10:
+      case 17:
         if (keyword.equals("ProductReplacementCount")) {
           ProductReplacementCount = u;
           break;
         }
-      case 11:
+      case 18:
         if (keyword.equals("ProductReviewLength")) {
           ProductReviewLength = u;
           break;
         }
-      case 12:
+      case 19:
         if (keyword.equals("RandomSeed")) {
           RandomSeed = u;
           break;
         }
-      case 13:
+      case 20:
         if (keyword.equals("ResponseTimeMeasurements")) {
           ResponseTimeMeasurements = u;
           break;
         }
-      case 14:
+      case 21:
         if (keyword.equals("SalesTransactionQueueCount")) {
           SalesTransactionQueueCount = u;
           break;
         }
-      case 15:
+      case 22:
         if (keyword.equals("SelectionCriteriaCount")) {
           SelectionCriteriaCount = u;
           break;
         }
-      case 16:
+      case 23:
         if (keyword.equals("ServerThreads")) {
           ServerThreads = u;
           break;
@@ -764,6 +827,40 @@ class Configuration {
     return MaxArrayLength;
   }
 
+  boolean SearchForMaximumTransactionRate() {
+    return ((MaxP50CustomerPrepMicroseconds > 0) || (MaxP95CustomerPrepMicroseconds > 0) || (MaxP99CustomerPrepMicroseconds > 0) ||
+	    (MaxP99_9CustomerPrepMicroseconds > 0) || (MaxP99_99CustomerPrepMicroseconds > 0) ||
+	    (MaxP99_999CustomerPrepMicroseconds > 0) || (MaxP100CustomerPrepMicroseconds > 0));
+  }
+
+  int MaxP50CustomerPrepMicroseconds() {
+    return MaxP50CustomerPrepMicroseconds;
+  }
+
+  int MaxP95CustomerPrepMicroseconds() {
+    return MaxP95CustomerPrepMicroseconds;
+  }
+
+  int MaxP99CustomerPrepMicroseconds() {
+    return MaxP99CustomerPrepMicroseconds;
+  }
+
+  int MaxP99_9CustomerPrepMicroseconds() {
+    return MaxP99_9CustomerPrepMicroseconds;
+  }
+
+  int MaxP99_99CustomerPrepMicroseconds() {
+    return MaxP99_99CustomerPrepMicroseconds;
+  }
+
+  int MaxP99_999CustomerPrepMicroseconds() {
+    return MaxP99_999CustomerPrepMicroseconds;
+  }
+
+  int MaxP100CustomerPrepMicroseconds() {
+    return MaxP100CustomerPrepMicroseconds;
+  }
+
   int NumCustomers() {
     return NumCustomers;
   }
@@ -931,6 +1028,48 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("ResponseTimeMeasurements,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP50CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP50CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP95CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP95CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP99CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_9CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP99_9CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_99CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP99_99CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_999CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP99_999CustomerPrepMicroseconds,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP100CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("MaxP100CustomerPrepMicroseconds,", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(DictionarySize);
@@ -1133,6 +1272,48 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("             Maximum array length (MaxArrayLength): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP50CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("    Max p50 latency (MaxP50CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP95CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("    Max p95 latency (MaxP95CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("    Max p99 latency (MaxP99CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_9CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("   Max p99_9 latency (MaxP99_9CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_99CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output(" Max p99_99 latency (MaxP99_999CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP99_999CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("    Max p99_999 latency (MaxP99_999CustomerPrepMicroseconds): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(MaxP100CustomerPrepMicroseconds);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("    Max p100 latency (MaxP100CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ResponseTimeMeasurements);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -1222,8 +1222,6 @@ class Configuration {
     Util.ephemeralString(t, l);
     Report.output("ProductReviewLength,", s);
     Util.abandonEphemeralString(t, l);
-
-
   }
 
   void dump(ExtrememThread t) {
@@ -1239,63 +1237,65 @@ class Configuration {
       Report.output(listOfArguments.get(i));
 
     Report.output();
-    Report.output("Individual thread report (ReportIndividualThreads): ",
+    Report.output("      Individual thread report (ReportIndividualThreads): ",
                   ReportIndividualThreads? "true": "false");
-    Report.output("                    Exporting to Excel (ReportCSV): ",
+    Report.output("                          Exporting to Excel (ReportCSV): ",
                   ReportCSV? "true": "false");
 
     Report.output();
     Report.output("Simulation configuration");
 
-    Report.output("  Fine-grain locking of data base (FastAndFurious): ", FastAndFurious? "true": "false");
-    Report.output("       Rebuild data base in phases (PhasedUpdates): ", PhasedUpdates? "true": "false");
+    Report.output("        Fine-grain locking of data base (FastAndFurious): ", FastAndFurious? "true": "false");
+    Report.output("             Rebuild data base in phases (PhasedUpdates): ", PhasedUpdates? "true": "false");
     Report.output();
     s = PhasedUpdateInterval.toString(t);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("  Time between data rebuild (PhasedUpdateInterval): ", s);
+    Report.output("        Time between data rebuild (PhasedUpdateInterval): ", s);
     Util.abandonEphemeralString(t, l);
 
 
     s = Integer.toString(RandomSeed);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Seed for random number generation (RandomSeed): ", s);
+    Report.output("          Seed for random number generation (RandomSeed): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = SimulationDuration.toString(t);
     l = s.length();
-    Report.output("                     Duration (SimulationDuration): ", s);
+    Report.output("                           Duration (SimulationDuration): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxArrayLength);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("             Maximum array length (MaxArrayLength): ", s);
+    Report.output("                   Maximum array length (MaxArrayLength): ", s);
     Util.abandonEphemeralString(t, l);
+
+    Report.output();
 
     s = Integer.toString(MaxP50CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Max p50 latency (MaxP50CustomerPrepMicroseconds): ", s);
+    Report.output("        Max p50 latency (MaxP50CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxP95CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Max p95 latency (MaxP95CustomerPrepMicroseconds): ", s);
+    Report.output("        Max p95 latency (MaxP95CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxP99CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Max p99 latency (MaxP99CustomerPrepMicroseconds): ", s);
+    Report.output("        Max p99 latency (MaxP99CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxP99_9CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("   Max p99_9 latency (MaxP99_9CustomerPrepMicroseconds): ", s);
+    Report.output("    Max p99_9 latency (MaxP99_9CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxP99_99CustomerPrepMicroseconds);
@@ -1307,40 +1307,42 @@ class Configuration {
     s = Integer.toString(MaxP99_999CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Max p99_999 latency (MaxP99_999CustomerPrepMicroseconds): ", s);
+    Report.output("Max p99_999 latency (MaxP99_999CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxP100CustomerPrepMicroseconds);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Max p100 latency (MaxP100CustomerPrepMicroseconds): ", s);
+    Report.output("      Max p100 latency (MaxP100CustomerPrepMicroseconds): ", s);
     Util.abandonEphemeralString(t, l);
+
+    Report.output();
 
     s = Integer.toString(ResponseTimeMeasurements);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("   Remembered responses (ResponseTimeMeasurements): ", s);
+    Report.output("         Remembered responses (ResponseTimeMeasurements): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(DictionarySize);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("              Words in dictionary (DictionarySize): ", s);
+    Report.output("                    Words in dictionary (DictionarySize): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = DictionaryFile;
-    Report.output("Full path name of dictionary file (DictionaryFile): ", s);
+    Report.output("      Full path name of dictionary file (DictionaryFile): ", s);
 
     s = Integer.toString(BrowsingHistoryQueueCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Browsing queue qty (BrowsingHistoryQueueCount): ", s);
+    Report.output("          Browsing queue qty (BrowsingHistoryQueueCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(SalesTransactionQueueCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("Transaction queue qty (SalesTransactionQueueCount): ", s);
+    Report.output("      Transaction queue qty (SalesTransactionQueueCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     Report.output("");
@@ -1349,36 +1351,36 @@ class Configuration {
     s = Integer.toString(ServerThreads);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("           Number of server threads (ServerThreads): ", s);
+    Report.output("                Number of server threads (ServerThreads): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = ServerPeriod.toString(t);
     l = s.length();
-    Report.output("                Server thread period (ServerPeriod): ", s);
+    Report.output("                     Server thread period (ServerPeriod): ", s);
     Util.abandonEphemeralString(t, l);
 
     Report.output("Customer maintenance");
 
     s = CustomerReplacementPeriod.toString(t);
-    Report.output("     Replacement period (CustomerReplacementPeriod): ", s);
+    Report.output("          Replacement period (CustomerReplacementPeriod): ", s);
     Util.abandonEphemeralString(t, s);
 
     s = Integer.toString(CustomerReplacementCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("       Replacement count (CustomerReplacementCount): ", s);
+    Report.output("            Replacement count (CustomerReplacementCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     Report.output("Product maintenance");
 
     s = ProductReplacementPeriod.toString(t);
-    Report.output("      Replacement period (ProductReplacementPeriod): ", s);
+    Report.output("           Replacement period (ProductReplacementPeriod): ", s);
     Util.abandonEphemeralString(t, s);
 
     s = Integer.toString(ProductReplacementCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("        Replacement count (ProductReplacementCount): ", s);
+    Report.output("             Replacement count (ProductReplacementCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     Report.output("");
@@ -1387,19 +1389,19 @@ class Configuration {
     s = Integer.toString(CustomerThreads);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("                Number of threads (CustomerThreads): ", s);
+    Report.output("                     Number of threads (CustomerThreads): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = CustomerPeriod.toString(t);
-    Report.output("                     Thread period (CustomerPeriod): ", s);
+    Report.output("                          Thread period (CustomerPeriod): ", s);
     Util.abandonEphemeralString(t, s);
 
     s = CustomerThinkTime.toString(t);
-    Report.output("                     Think time (CustomerThinkTime): ", s);
+    Report.output("                          Think time (CustomerThinkTime): ", s);
     Util.abandonEphemeralString(t, s);
 
     s = BrowsingExpiration.toString(t);
-    Report.output("       Save-for-later duration (BrowsingExpiration): ", s);
+    Report.output("            Save-for-later duration (BrowsingExpiration): ", s);
     Util.abandonEphemeralString(t, s);
 
     Report.output("");
@@ -1408,19 +1410,19 @@ class Configuration {
     s = Integer.toString(NumCustomers);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("                              Number (NumCustomers): ", s);
+    Report.output("                                   Number (NumCustomers): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(KeywordSearchCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("                Words in query (KeywordSearchCount): ", s);
+    Report.output("                     Words in query (KeywordSearchCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(SelectionCriteriaCount);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("           Words to select (SelectionCriteriaCount): ", s);
+    Report.output("                Words to select (SelectionCriteriaCount): ", s);
     Util.abandonEphemeralString(t, l);
 
     Report.output(" Decision ratios:");
@@ -1448,25 +1450,25 @@ class Configuration {
     s = Integer.toString(NumProducts);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("                               Number (NumProducts): ", s);
+    Report.output("                                    Number (NumProducts): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ProductNameLength);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("                  Words in name (ProductNameLength): ", s);
+    Report.output("                       Words in name (ProductNameLength): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ProductDescriptionLength);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("    Words in description (ProductDescriptionLength): ", s);
+    Report.output("         Words in description (ProductDescriptionLength): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ProductReviewLength);
     l = s.length();
     Util.ephemeralString(t, l);
-    Report.output("              Words in review (ProductReviewLength): ", s);
+    Report.output("                   Words in review (ProductReviewLength): ", s);
     Util.abandonEphemeralString(t, l);
   }
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -469,37 +469,37 @@ class Configuration {
         }
       case 6:
         if (keyword.equals("MaxP50CustomerPrepMicroseconds")) {
-          MaxP50CustomerPrepMicroseconds = u;
+          MaxP50CustomerPrepMicroseconds = ui;
           break;
         }
       case 7:
         if (keyword.equals("MaxP95CustomerPrepMicroseconds")) {
-          MaxP95CustomerPrepMicroseconds = u;
+          MaxP95CustomerPrepMicroseconds = ui;
           break;
         }
       case 8:
         if (keyword.equals("MaxP99CustomerPrepMicroseconds")) {
-          MaxP99CustomerPrepMicroseconds = u;
+          MaxP99CustomerPrepMicroseconds = ui;
           break;
         }
       case 9:
         if (keyword.equals("MaxP99_9CustomerPrepMicroseconds")) {
-          MaxP99_9CustomerPrepMicroseconds = u;
+          MaxP99_9CustomerPrepMicroseconds = ui;
           break;
         }
       case 10:
         if (keyword.equals("MaxP99_99CustomerPrepMicroseconds")) {
-          MaxP99_99CustomerPrepMicroseconds = u;
+          MaxP99_99CustomerPrepMicroseconds = ui;
           break;
         }
       case 11:
         if (keyword.equals("MaxP99_999CustomerPrepMicroseconds")) {
-          MaxP99_999CustomerPrepMicroseconds = u;
+          MaxP99_999CustomerPrepMicroseconds = ui;
           break;
         }
       case 12:
         if (keyword.equals("MaxP100CustomerPrepMicroseconds")) {
-          MaxP100CustomerPrepMicroseconds = u;
+          MaxP100CustomerPrepMicroseconds = ui;
           break;
         }
       case 13:

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
@@ -74,6 +74,10 @@ class CustomerLog extends ExtrememObject {
     do_nothing_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
   }
 
+  public ResponseTimeMeasurements getPreparationResponseTimes() {
+   return prepare_response_times;
+  }
+
   // This information is redundant with purchaser.  I'll gather it
   // here, and ignore it when logging purchases.
   void logPrepareToThink(CustomerThread t, AbsoluteTime release,

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -8,6 +8,9 @@ class CustomerThread extends ExtrememThread {
   private static final int SaveProductForLater = 1;
   private static final int AbandonProduct = 2;
 
+  private final RelativeTime period;
+  private final RelativeTime think_time;
+
   private final Customers all_customers;
   private final Products all_products;
   private AbsoluteTime next_release_time;
@@ -33,13 +36,10 @@ class CustomerThread extends ExtrememThread {
    * The Bootstrap thread accounts for this CustomerThread instance's
    * garbage.
    */
-  CustomerThread (Configuration config, long random_seed, int sequence_no,
-                  Products all_products, Customers all_customers,
-                  BrowsingHistoryQueue browsing_queue,
-                  SalesTransactionQueue sales_queue,
-                  CustomerLogAccumulator accumulator,
-                  MemoryLog alloc_accumulator,
-                  MemoryLog garbage_accumulator) {
+  CustomerThread (Configuration config, RelativeTime period, RelativeTime think_time, long random_seed, int sequence_no,
+                  Products all_products, Customers all_customers, BrowsingHistoryQueue browsing_queue,
+                  SalesTransactionQueue sales_queue,  CustomerLogAccumulator accumulator,
+                  MemoryLog alloc_accumulator, MemoryLog garbage_accumulator) {
     super (config, random_seed);
     MemoryLog log = this.memoryLog();
     MemoryLog garbage = this.garbageLog();
@@ -53,6 +53,10 @@ class CustomerThread extends ExtrememThread {
               ": CustomerThread[", label, "].garbageLog()");
     
     Util.convertEphemeralString(this, LifeSpan.NearlyForever, label.length());
+
+    this.period = period;
+    this.think_time = think_time;
+
     this.all_customers = all_customers;
     this.all_products = all_products;
     this.browsing_queue = browsing_queue;
@@ -178,8 +182,7 @@ class CustomerThread extends ExtrememThread {
         Util.convertStringArray(this, LifeSpan.TransientShort,
                                 selectors.length);
 
-        AbsoluteTime end_think = (
-          next_release_time.addRelative(this, config.CustomerThinkTime()));
+        AbsoluteTime end_think = next_release_time.addRelative(this, this.think_time);
         end_think.changeLifeSpan(this, LifeSpan.TransientShort);
         history.logPrepareToThink(this, next_release_time,
                                   all_count, any_count, saved_count);
@@ -293,9 +296,7 @@ class CustomerThread extends ExtrememThread {
         history.logNoChoice(this, next_release_time);
       }
       next_release_time.garbageFootprint(this);
-      next_release_time = next_release_time.addRelative(this,
-                                                        config.
-                                                        CustomerPeriod());
+      next_release_time = next_release_time.addRelative(this, this.period);
     }
     Trace.msg(2, "Customer thread ", label, " terminating.  Time is up.");
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTime.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTime.java
@@ -246,6 +246,23 @@ class RelativeTime extends HighResolutionTime {
 
   /**
    * Return a new Ephemeral RelativeTime instance representing the
+   * product of multiplying this by divisor.
+   *
+   * The code that invokes this service is expected to account for the
+   * returned RelativeTime object's memory eventually becoming garbage,
+   * possibly adjusting the accounting of its LifeSpan along the way
+   * to becoming garbage. 
+   */
+  RelativeTime multiplyBy(ExtrememThread t, double factor) {
+    double original = this.s + this.ns / (1000000000.0);
+    double result = original * factor;
+    long s = (long) result;
+    long ns = (long) ((result - s) * 1000000000);
+    return new RelativeTime(t, s, (int) ns);
+  }
+
+  /**
+   * Return a new Ephemeral RelativeTime instance representing the
    * quotient of dividing this by divisor.
    *
    * The code that invokes this service is expected to account for the

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
@@ -19,6 +19,7 @@ import java.io.PrintStream;
 class Report {
   private static final Object locker = new Object();
   private static final PrintStream out = System.out;
+  private static final PrintStream err = System.err;
   private static int num_writers;
 
   // "varargs" formats avoid autoboxing and catenation costs
@@ -40,6 +41,25 @@ class Report {
       num_writers--;
       locker.notifyAll();
     }
+  }
+
+  static void errout() {
+    err.println("");
+  }
+
+  static void errout(String s1) {
+    err.println(s1);
+  }
+
+  static void errout(String s1, String s2) {
+    err.print(s1);
+    err.println(s2);
+  }
+
+  static void errout(String s1, String s2, String s3) {
+    err.print(s1);
+    err.print(s2);
+    err.println(s3);
   }
 
   static void output() {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Report.java
@@ -62,6 +62,24 @@ class Report {
     err.println(s3);
   }
 
+  static void errout(String s1, String s2, String s3, String s4, String s5) {
+    err.print(s1);
+    err.print(s2);
+    err.print(s3);
+    err.print(s4);
+    err.println(s5);
+  }
+
+  static void errout(String s1, String s2, String s3,
+                     String s4, String s5, String s6) {
+    err.print(s1);
+    err.print(s2);
+    err.print(s3);
+    err.print(s4);
+    err.print(s5);
+    err.println(s6);
+  }
+
   static void output() {
     out.println("");
   }


### PR DESCRIPTION
This PR adds a capability to allow Extremem to automatically search for the maximum transaction rate that supports a particular SLA.  If a maximum latency is specified for the P50, P95, P99, P99_9, P99_99, P99_999, or P100 percentiles
of the Customer Preparation Processing time, Extremem will run the test multiple times in search of a maximum transaction
rate that supports the specified SLA constraint.

Previous command-line configurations are unaffected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
