### PR TITLE
Introduce warmup delay

### DIFF
--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -281,7 +281,16 @@ Each server thread replaces ProductReplacementCount products once every ProductR
 
 ### *-dSimulationDuration=10m*
 
-The simulation ends after all customer and server threads have been running for this amount of time.  The threads do not begin to run until InitializationDelay has passed since the start of execution, assuring that all global and thread-local data structures have been initialized prior to the start of the simulation run.  Thus, the true expected duration of the simulation run equals the total number of server and customer threads multiplied by 500 microseconds, plus the InitializationDelay, plus SimulationDuration, plus whatever additional time is required to produce the report that describes the performance and latency metrics for the simulated workload.  Each customer thread and each server thread terminates as soon as it confirms that the start of its next execution period would occur after the intended end of the simulation.  Thus, it is possible that the simulation will begin reporting results even before the requested end time for the simulation.
+The simulation ends after all customer and server threads have been running for this amount of time.  The simulation begins
+after all shared data structures have been initialized and all threads have been started.  Each customer and server thread
+initially waits until the computed time for the simulation is reached.  Each customer thread and each server thread terminfates
+as soon as it confirms that the start of its next execution period would occur after the intended end of the simulation.
+
+### *-dWarmupDuration=0s*
+
+Specification of a warmup delay allows the simulated workload to run for a specified amount of time before it begins to
+accumulate measured latencies.  The WarmupDuation is added to SimulatedDuration.  When searching for a maximum supported
+transaction rate, the WarmupDuration is applied to each experimental run.
 
 ### *-dReportIndividualThreads=false*
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Bootstrap.java
@@ -232,7 +232,7 @@ public class Bootstrap extends ExtrememThread {
         delay_until.sleep(this);
       }
     } else {
-      configure_simulation_threads(true);
+      configure_simulation_threads();
       boolean success = run_one_experiment(false);
       if (success) {
         Report.output("Simulation was successful");
@@ -497,28 +497,33 @@ public class Bootstrap extends ExtrememThread {
 
     if (now.compare(_start_time) > 0) {
       Report.output("Warning!  Consumed more than 4 ms to start each thread.");
-      s = _start_time.toString(this);
-      Report.output(" Planned to start at: ", s);
-      s = now.toString(this);
-      Report.output("Actually starting at: ", s);
+      if (_config.ReportCSV()) {
+        s = Long.toString(_start_time.microseconds());
+        Report.output(" Planned to start at, ", s);
+        s = Long.toString(now.microseconds());
+        Report.output(" Actually starting at, ", s);
+      } else {
+        s = _start_time.toString(this);
+        Report.output(" Planned to start at: ", s);
+        s = now.toString(this);
+        Report.output(" Actually starting at: ", s);
+      }
     }
     _start_time.garbageFootprint(this);
     _start_time = null;
     _end_time.changeLifeSpan(this, LifeSpan.NearlyForever);
 
-    if (needs_warmup) {
-      now = _start_logging_time.sleep(this);
-      if (_config.ReportCSV()) {
-        s = Long.toString(now.microseconds());
-        Util.ephemeralString(this, s.length());
-        Report.output("Starting to log results time,", s);
-      } else {
-        s = now.toString(this);
-        Report.output("");
-        Report.output("Starting to log results at time: ", s);
-      }
-      Util.abandonEphemeralString(this, s);
+    now = _start_logging_time.sleep(this);
+    if (_config.ReportCSV()) {
+      s = Long.toString(now.microseconds());
+      Util.ephemeralString(this, s.length());
+      Report.output("Starting to log results time,", s);
+    } else {
+      s = now.toString(this);
+      Report.output("");
+      Report.output("Starting to log results at time: ", s);
     }
+    Util.abandonEphemeralString(this, s);
 
     now.garbageFootprint(this);
     now = null;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -87,6 +87,7 @@ class Configuration {
   static final int DefaultPhasedUpdateIntervalSeconds = 60;
 
   static final long DefaultDurationMinutes = 10;
+  static final long DefaultWarmupSeconds = 0;
 
   /*
    * Instance fields begin here.
@@ -123,6 +124,7 @@ class Configuration {
   private Words dictionary;
 
   private RelativeTime SimulationDuration;
+  private RelativeTime WarmupDuration;
 
   private RelativeTime CustomerPeriod;
   private RelativeTime CustomerThinkTime;
@@ -196,12 +198,12 @@ class Configuration {
                    Polarity.Expand, 24 * Util.SizeOfInt +
                    2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
-    // Account for 10 reference fields: args, dictionary,
-    // DictionaryFile, SimulationDuration,
+    // Account for 11 reference fields: args, dictionary,
+    // DictionaryFile, SimulationDuration, WarmupDuration,
     // CustomerPeriod, CustomerThinkTime, ServerPeriod, BrowsingExpiration,
     // CustomerReplacementPeriod, ProductReplacementPeriod.
     log.accumulate(LifeSpan.NearlyForever,
-                   MemoryFlavor.ObjectReference, Polarity.Expand, 10);
+                   MemoryFlavor.ObjectReference, Polarity.Expand, 11);
 
     ResponseTimeMeasurements = DefaultResponseTimeMeasurements;
     ReportIndividualThreads = DefaultReportIndividualThreads;
@@ -229,6 +231,9 @@ class Configuration {
     AllowAnyMatch = DefaultAllowAnyMatch;
     FastAndFurious = DefaultFastAndFurious;
     PhasedUpdates = DefaultPhasedUpdates;
+
+    WarmupDuration = new RelativeTime(t, DefaultWarmupSeconds, 0);
+    WarmupDuration.changeLifeSpan(t, LifeSpan.NearlyForever);
 
     SimulationDuration = new RelativeTime(t, DefaultDurationMinutes * 60, 0);
     SimulationDuration.changeLifeSpan(t, LifeSpan.NearlyForever);
@@ -332,6 +337,7 @@ class Configuration {
     "ProductReplacementPeriod",
     "ServerPeriod",
     "SimulationDuration",
+    "WarmupDuration",
   };
 
   private static String[] name_patterns = {
@@ -696,6 +702,13 @@ class Configuration {
           SimulationDuration.changeLifeSpan(t, LifeSpan.NearlyForever);
           break;
         }
+      case 9:
+        if (keyword.equals("WarmupDuration")) {
+          WarmupDuration.garbageFootprint(t);
+          WarmupDuration = new RelativeTime(t, secs, nanos);
+          WarmupDuration.changeLifeSpan(t, LifeSpan.NearlyForever);
+          break;
+        }
       default:
         usage("Unexpected internal error in doTimeArg");
     }
@@ -938,6 +951,10 @@ class Configuration {
     return SimulationDuration;
   }
 
+  RelativeTime WarmupDuration() {
+    return WarmupDuration;
+  }
+
   RelativeTime CustomerPeriod() {
     return CustomerPeriod;
   }
@@ -1040,6 +1057,12 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("SimulationDuration,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Long.toString(WarmupDuration.microseconds());
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("WarmupDuration,", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(MaxArrayLength);
@@ -1294,6 +1317,11 @@ class Configuration {
     Report.output("                           Duration (SimulationDuration): ", s);
     Util.abandonEphemeralString(t, l);
 
+    s = WarmupDuration.toString(t);
+    l = s.length();
+    Report.output("                                 Warmup (WarmupDuration): ", s);
+    Util.abandonEphemeralString(t, l);
+
     s = Integer.toString(MaxArrayLength);
     l = s.length();
     Util.ephemeralString(t, l);
@@ -1523,12 +1551,12 @@ class Configuration {
                        Grow, 17 * Util.SizeOfInt +
                        2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
-    // Account for 10 reference fields: args, dictionary, DictionaryFile
-    // SimulationDuration, CustomerPeriod,
+    // Account for 11 reference fields: args, dictionary, DictionaryFile
+    // SimulationDuration, WarmupDuration, CustomerPeriod,
     // CustomerThinkTime, ServerPeriod, BrowsingExpiration,
     // CustomerReplacementPeriod, ProductReplacementPeriod 
     garbage.accumulate(LifeSpan.NearlyForever,
-                       MemoryFlavor.ObjectReference, Polarity.Expand, 10);
+                       MemoryFlavor.ObjectReference, Polarity.Expand, 11);
 
     Util.tallyString(t.garbageLog(), LifeSpan.NearlyForever,
                      Polarity.Expand, DictionaryFile.length());


### PR DESCRIPTION
This PR allows command-line specification of a warmup delay.  The warmup delay is added to the SimulationDuration.  Logging of response times does not begin until after the warmup delay has been consumed within each simulation run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
