### PR TITLE
Improve wind-down processing at end of simulation

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -40,6 +40,16 @@ class Configuration {
   static final boolean DefaultFastAndFurious = false;
   static final boolean DefaultPhasedUpdates = false;
   static final boolean DefaultAllowAnyMatch = true;
+  static final boolean DefaultDumpAbandonmentResponseTimes = false;
+  static final boolean DefaultDumpBrowsingHistoryResponseTimes = false;
+  static final boolean DefaultDumpCustomerDoNothingResponseTimes = false;
+  static final boolean DefaultDumpCustomerReplacementResponseTimes = false;
+  static final boolean DefaultDumpPreparationResponseTimes = false;
+  static final boolean DefaultDumpProductReplacementResponseTimes = false;
+  static final boolean DefaultDumpPurchaseResponseTimes = false;
+  static final boolean DefaultDumpSalesTransactionResponseTimes = false;
+  static final boolean DefaultDumpSaveForLaterResponseTimes = false;
+  static final boolean DefaultDumpServerDoNothingResponseTimes = false;
 
   static final int DefaultDictionarySize = 25000;
   static final String DefaultDictionaryFile = "/usr/share/dict/words";
@@ -114,8 +124,18 @@ class Configuration {
   private int ServerThreads;
 
   private boolean AllowAnyMatch;
+  private boolean DumpAbandonmentResponseTimes;
+  private boolean DumpBrowsingHistoryResponseTimes;
+  private boolean DumpCustomerDoNothingResponseTimes;
+  private boolean DumpCustomerReplacementResponseTimes;
+  private boolean DumpPreparationResponseTimes;
+  private boolean DumpProductReplacementResponseTimes;
+  private boolean DumpPurchaseResponseTimes;
+  private boolean DumpSalesTransactionResponseTimes;
+  private boolean DumpSaveForLaterResponseTimes;
+  private boolean DumpServerDoNothingResponseTimes;
   private boolean FastAndFurious;
-  private boolean PhasedUpdates;;
+  private boolean PhasedUpdates;
   private boolean ReportIndividualThreads;
   private boolean ReportCSV;
 
@@ -217,6 +237,17 @@ class Configuration {
     Util.tallyString(t.memoryLog(), LifeSpan.NearlyForever,
                      Polarity.Expand, DictionaryFile.length());
 
+    DumpAbandonmentResponseTimes = DefaultDumpAbandonmentResponseTimes;
+    DumpBrowsingHistoryResponseTimes = DefaultDumpBrowsingHistoryResponseTimes;
+    DumpCustomerDoNothingResponseTimes = DefaultDumpCustomerDoNothingResponseTimes;
+    DumpCustomerReplacementResponseTimes = DefaultDumpCustomerReplacementResponseTimes;
+    DumpPreparationResponseTimes = DefaultDumpPreparationResponseTimes;
+    DumpProductReplacementResponseTimes = DefaultDumpProductReplacementResponseTimes;
+    DumpPurchaseResponseTimes = DefaultDumpPurchaseResponseTimes;
+    DumpSalesTransactionResponseTimes = DefaultDumpSalesTransactionResponseTimes;
+    DumpSaveForLaterResponseTimes = DefaultDumpSaveForLaterResponseTimes;
+    DumpServerDoNothingResponseTimes = DefaultDumpServerDoNothingResponseTimes;
+
     MaxArrayLength = DefaultMaxArrayLength;
     MaxP50CustomerPrepMicroseconds = DefaultMaxP50CustomerPrepMicroseconds;
     MaxP95CustomerPrepMicroseconds = DefaultMaxP95CustomerPrepMicroseconds;
@@ -296,6 +327,16 @@ class Configuration {
 
   private static String[] boolean_patterns = {
     "AllowAnyMatch",
+    "DumpAbandonmentResponseTimes",
+    "DumpBrowsingHistoryResponseTimes",
+    "DumpCustomerDoNothingResponseTimes",
+    "DumpCustomerReplacementResponseTimes",
+    "DumpPreparationResponseTimes",
+    "DumpProductReplacementResponseTimes",
+    "DumpPurchaseResponseTimes",
+    "DumpSalesTransactionResponseTimes",
+    "DumpSaveForLaterResponseTimes",
+    "DumpServerDoNothingResponseTimes",
     "FastAndFurious",
     "PhasedUpdates",
     "ReportCSV",
@@ -412,21 +453,71 @@ class Configuration {
           break;
         }
       case 1:
+        if (keyword.equals("DumpAbandonmentResponseTimes")) {
+          DumpAbandonmentResponseTimes = b;
+          break;
+        }
+      case 2:
+        if (keyword.equals("DumpBrowsingHistoryResponseTimes")) {
+          DumpBrowsingHistoryResponseTimes = b;
+          break;
+        }
+      case 3:
+        if (keyword.equals("DumpCustomerDoNothingResponseTimes")) {
+          DumpCustomerDoNothingResponseTimes = b;
+          break;
+        }
+      case 4:
+        if (keyword.equals("DumpCustomerReplacementResponseTimes")) {
+          DumpCustomerReplacementResponseTimes = b;
+          break;
+        }
+      case 5:
+        if (keyword.equals("DumpPreparationResponseTimes")) {
+          DumpPreparationResponseTimes = b;
+          break;
+        }
+      case 6:
+        if (keyword.equals("DumpProductReplacementResponseTimes")) {
+          DumpProductReplacementResponseTimes = b;
+          break;
+        }
+      case 7:
+        if (keyword.equals("DumpPurchaseResponseTimes")) {
+          DumpPurchaseResponseTimes = b;
+          break;
+        }
+      case 8:
+        if (keyword.equals("DumpSalesTransactionResponseTimes")) {
+          DumpSalesTransactionResponseTimes = b;
+          break;
+        }
+      case 9:
+        if (keyword.equals("DumpSaveForLaterResponseTimes")) {
+          DumpSaveForLaterResponseTimes = b;
+          break;
+        }
+      case 10:
+        if (keyword.equals("DumpServerDoNothingResponseTimes")) {
+          DumpServerDoNothingResponseTimes = b;
+          break;
+        }
+      case 11:
         if (keyword.equals("FastAndFurious")) {
           FastAndFurious = b;
           break;
         }
-      case 2:
+      case 12:
         if (keyword.equals("PhasedUpdates")) {
           PhasedUpdates = b;
           break;
         }
-      case 3:
+      case 13:
         if (keyword.equals("ReportCSV")) {
           ReportCSV = b;
           break;
         }
-      case 4:
+      case 14:
         if (keyword.equals("ReportIndividualThreads")) {
           ReportIndividualThreads = b;
           break;
@@ -866,6 +957,46 @@ class Configuration {
     return PhasedUpdates;
   }
 
+  boolean DumpAbandonmentResponseTimes() {
+    return DumpAbandonmentResponseTimes;
+  }
+
+  boolean DumpBrowsingHistoryResponseTimes() {
+    return DumpBrowsingHistoryResponseTimes;
+  }
+
+  boolean DumpCustomerDoNothingResponseTimes() {
+    return DumpCustomerDoNothingResponseTimes;
+  }
+
+  boolean DumpCustomerReplacementResponseTimes() {
+    return DumpCustomerReplacementResponseTimes;
+  }
+
+  boolean DumpPreparationResponseTimes() {
+    return DumpPreparationResponseTimes;
+  }
+
+  boolean DumpProductReplacementResponseTimes() {
+    return DumpProductReplacementResponseTimes;
+  }
+
+  boolean DumpPurchaseResponseTimes() {
+    return DumpPurchaseResponseTimes;
+  }
+
+  boolean DumpSalesTransactionResponseTimes() {
+    return DumpSalesTransactionResponseTimes;
+  }
+
+  boolean DumpSaveForLaterResponseTimes() {
+    return DumpSaveForLaterResponseTimes;
+  }
+
+  boolean DumpServerDoNothingResponseTimes() {
+    return DumpServerDoNothingResponseTimes;
+  }
+
   int MaxArrayLength() {
     return MaxArrayLength;
   }
@@ -1039,10 +1170,17 @@ class Configuration {
       Report.outputNoLine(",arg:", listOfArguments.get(i));
 
     Report.output();
-    Report.output("ReportIndividualThreads,",
-                  ReportIndividualThreads? "true": "false");
-    Report.output("ReportCSV,", ReportCSV? "true": "false");
+    Report.output("ReportIndividualThreads,", ReportIndividualThreads? "true": "false");
+    Report.output("ReportCSV,",               ReportCSV? "true": "false");
 
+    Report.output("DumpCustomerDoNothingResponseTimes", DumpCustomerDoNothingResponseTimes? "true": "false");
+    Report.output("DumpCustomerReplacementResponseTimes", DumpCustomerReplacementResponseTimes? "true": "false");
+    Report.output("DumpPreparationResponseTimes", DumpPreparationResponseTimes? "true": "false");
+    Report.output("DumpProductReplacementResponseTimes", DumpProductReplacementResponseTimes? "true": "false");
+    Report.output("DumpPurchaseResponseTimes", DumpPurchaseResponseTimes? "true": "false");
+    Report.output("DumpSalesTransactionResponseTimes", DumpSalesTransactionResponseTimes? "true": "false");
+    Report.output("DumpSaveForLaterResponseTimes", DumpSaveForLaterResponseTimes? "true": "false");
+    Report.output("DumpServerDoNothingResponseTimes", DumpServerDoNothingResponseTimes? "true": "false");
 
     Report.output("Simulation configuration");
 
@@ -1298,10 +1436,21 @@ class Configuration {
       Report.output(listOfArguments.get(i));
 
     Report.output();
-    Report.output("      Individual thread report (ReportIndividualThreads): ",
-                  ReportIndividualThreads? "true": "false");
-    Report.output("                          Exporting to Excel (ReportCSV): ",
-                  ReportCSV? "true": "false");
+    Report.output("      Individual thread report (ReportIndividualThreads): ", ReportIndividualThreads? "true": "false");
+    Report.output("                          Exporting to Excel (ReportCSV): ", ReportCSV? "true": "false");
+    Report.output("                      DumpCustomerDoNothingResponseTimes: ",
+                  DumpCustomerDoNothingResponseTimes? "true": "false");
+    Report.output("                    DumpCustomerReplacementResponseTimes: ",
+                  DumpCustomerReplacementResponseTimes? "true": "false");
+    Report.output("                            DumpPreparationResponseTimes: ", DumpPreparationResponseTimes? "true": "false");
+    Report.output("                     DumpProductReplacementResponseTimes: ",
+                  DumpProductReplacementResponseTimes? "true": "false");
+    Report.output("                               DumpPurchaseResponseTimes: ", DumpPurchaseResponseTimes? "true": "false");
+    Report.output("                       DumpSalesTransactionResponseTimes: ",
+                  DumpSalesTransactionResponseTimes? "true": "false");
+    Report.output("                           DumpSaveForLaterResponseTimes: ", DumpSaveForLaterResponseTimes? "true": "false");
+    Report.output("                        DumpServerDoNothingResponseTimes: ", DumpServerDoNothingResponseTimes? "true": "false");
+
 
     Report.output();
     Report.output("Simulation configuration");

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -134,6 +134,8 @@ class Configuration {
 
   private RelativeTime PhasedUpdateInterval;
 
+  private RelativeTime LongestPriod;
+
   // Multiple concurrent Server threads execute with the same period,
   // with different stagger values.
   private RelativeTime CustomerReplacementPeriod;
@@ -150,6 +152,8 @@ class Configuration {
   private int SelectionCriteriaCount;
   private float BuyThreshold;
   private float SaveForLaterThreshold;
+
+  private RelativeTime LongestPeriod;
 
   Configuration(String[] args) {
     this.args = args;
@@ -282,6 +286,9 @@ class Configuration {
 
     parseArguments(t, args);
     assureConfiguration(t);
+
+    LongestPeriod = (ServerPeriod.compare(CustomerPeriod) > 0)? ServerPeriod: CustomerPeriod;
+
     t.replaceSeed(RandomSeed);
     dictionary = new Words(t, DictionaryFile, LifeSpan.NearlyForever,
                            DictionarySize, MaxArrayLength);
@@ -953,6 +960,10 @@ class Configuration {
 
   RelativeTime WarmupDuration() {
     return WarmupDuration;
+  }
+
+  RelativeTime LongestPeriod() {
+    return LongestPeriod;
   }
 
   RelativeTime CustomerPeriod() {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
@@ -195,19 +195,19 @@ class CustomerLog extends ExtrememObject {
   }
 
   void prepareToReport(String thread_label) {
-      String label = (_dump_prepare_response_times)? thread_label + ":prepare_response_times": null;
+      String label = (_dump_prepare_response_times)? thread_label + ":PreparationResponseTimes": null;
     prepare_response_times.prep_for_reporting(label);
 
-    label = (_dump_purchase_response_times)? thread_label + ":purchase_response_times": null;
+    label = (_dump_purchase_response_times)? thread_label + ":PurchaseResponseTimes": null;
     purchase_response_times.prep_for_reporting(label);
 
-    label = (_dump_save_for_later_response_times)? thread_label + ":save_for_later_response_times": null;
+    label = (_dump_save_for_later_response_times)? thread_label + ":SaveForLaterResponseTimes": null;
     save_for_later_response_times.prep_for_reporting(label);
 
-    label = (_dump_abandonment_response_times)? thread_label + ":abandonment_response_times": null;
+    label = (_dump_abandonment_response_times)? thread_label + ":AbandonmentResponseTimes": null;
     abandonment_response_times.prep_for_reporting(label);
 
-    label = (_dump_do_nothing_response_times)? thread_label + ":do_nothing_response_times": null;
+    label = (_dump_do_nothing_response_times)? thread_label + ":CustomerDoNothingResponseTimes": null;
     do_nothing_response_times.prep_for_reporting(label);
   }
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
@@ -41,13 +41,25 @@ class CustomerLog extends ExtrememObject {
   int total_abandoned;
   int total_do_nothings;
 
-  ResponseTimeMeasurements prepare_response_times;
-  ResponseTimeMeasurements purchase_response_times;
-  ResponseTimeMeasurements save_for_later_response_times;
-  ResponseTimeMeasurements abandonment_response_times;
-  ResponseTimeMeasurements do_nothing_response_times;
+  final ResponseTimeMeasurements prepare_response_times;
+  final ResponseTimeMeasurements purchase_response_times;
+  final ResponseTimeMeasurements save_for_later_response_times;
+  final ResponseTimeMeasurements abandonment_response_times;
+  final ResponseTimeMeasurements do_nothing_response_times;
+
+  final boolean _dump_prepare_response_times;
+  final boolean _dump_purchase_response_times;
+  final boolean _dump_save_for_later_response_times;
+  final boolean _dump_abandonment_response_times;
+  final boolean _dump_do_nothing_response_times;
 
   CustomerLog(ExtrememThread t, LifeSpan ls, int response_time_measurements) {
+    this(t, ls, response_time_measurements, false, false, false, false, false);
+  }
+
+  CustomerLog(ExtrememThread t, LifeSpan ls, int response_time_measurements,
+              boolean dump_prepare_tallies, boolean dump_purchase_tallies, boolean dump_save_tallies,
+              boolean dump_abandonment_tallies, boolean dump_do_nothing_tallies) {
     super(t, ls);
     MemoryLog log = t.memoryLog();
     Polarity Grow = Polarity.Expand;
@@ -72,6 +84,12 @@ class CustomerLog extends ExtrememObject {
     save_for_later_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
     abandonment_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
     do_nothing_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
+
+    _dump_prepare_response_times = dump_prepare_tallies;
+    _dump_purchase_response_times = dump_purchase_tallies;
+    _dump_save_for_later_response_times = dump_save_tallies;
+    _dump_abandonment_response_times = dump_abandonment_tallies;
+    _dump_do_nothing_response_times = dump_do_nothing_tallies;
   }
 
   public ResponseTimeMeasurements getPreparationResponseTimes() {
@@ -174,6 +192,23 @@ class CustomerLog extends ExtrememObject {
 
   int engagements() {
     return engagements;
+  }
+
+  void prepareToReport(String thread_label) {
+      String label = (_dump_prepare_response_times)? thread_label + ":prepare_response_times": null;
+    prepare_response_times.prep_for_reporting(label);
+
+    label = (_dump_purchase_response_times)? thread_label + ":purchase_response_times": null;
+    purchase_response_times.prep_for_reporting(label);
+
+    label = (_dump_save_for_later_response_times)? thread_label + ":save_for_later_response_times": null;
+    save_for_later_response_times.prep_for_reporting(label);
+
+    label = (_dump_abandonment_response_times)? thread_label + ":abandonment_response_times": null;
+    abandonment_response_times.prep_for_reporting(label);
+
+    label = (_dump_do_nothing_response_times)? thread_label + ":do_nothing_response_times": null;
+    do_nothing_response_times.prep_for_reporting(label);
   }
 
   void report(ExtrememThread t, String label, boolean reportCSV) {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -67,7 +67,10 @@ class CustomerThread extends ExtrememThread {
     this.alloc_accumulator = alloc_accumulator;
     this.garbage_accumulator = garbage_accumulator;
     
-    history = new CustomerLog(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements());
+    history = new CustomerLog(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements(),
+                              config.DumpPreparationResponseTimes(), config.DumpPurchaseResponseTimes(),
+                              config.DumpSaveForLaterResponseTimes(), config.DumpAbandonmentResponseTimes(),
+                              config.DumpCustomerDoNothingResponseTimes());
     
     // Account for 12 reference fields: label, all_customers,
     // all_products, next_release_time, start_logging_time, end_simulation_time,
@@ -333,7 +336,7 @@ class CustomerThread extends ExtrememThread {
       next_release_time = next_release_time.addRelative(this, this.period);
     }
     Trace.msg(2, "Customer thread ", label, " terminating.  Time is up.");
-
+    history.prepareToReport("Customer" + getLabel());
     // We accumulate accumulator even if reporting individual threads
     accumulator.accumulate(history);
     if (config.ReportIndividualThreads())

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -90,10 +90,14 @@ class CustomerThread extends ExtrememThread {
   public void runExtreme() {
     boolean logging = false;
     while (true) {
-      // If the simulation will have ended before we wake up, don't
-      // even bother to sleep.
-      if (next_release_time.compare(end_simulation_time) >= 0)
+      // If the simulation will have ended before we wake up, don't bother to trigger next transaction
+      if (next_release_time.compare(end_simulation_time) >= 0) {
+        // Wait one period beyond end simulation time to make sure all Customer and Server work is completed
+        // before we begin report generation.
+        AbsoluteTime end_execution_time = end_simulation_time.addRelative(this, config.LongestPeriod());
+        end_execution_time.sleep(this);
         break;
+      }
 
       AbsoluteTime now = next_release_time.sleep(this);
       Customer customer = all_customers.selectRandomCustomer(this);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ResponseTimeMeasurements.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ResponseTimeMeasurements.java
@@ -51,7 +51,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
 
   void addToLog(ResponseTimeMeasurements other) {
     if (total_entries > 0) {
-      other.prep_for_reporting();
+      other.prep_for_reporting(null);
       for (int i = 0; i < other.logged_entries; i++) {
         addToLog(other.log[(other.first_entry + i) % total_entries]);
       }
@@ -84,7 +84,16 @@ class ResponseTimeMeasurements extends ExtrememObject {
     return logged_entries;
   }
 
-  private void prep_for_reporting() {
+  public void prep_for_reporting(String label) {
+    if (label != null) {
+      Report.acquireReportLock();
+      Report.output(label);
+      for (int i = 0; i < logged_entries; i++) {
+        Report.output(Long.toString(log[i]));
+      }
+      Report.releaseReportLock();
+    }
+
     if (logged_entries > 0) {
       if (logged_entries < total_entries) {
         java.util.Arrays.sort(log, 0, logged_entries);
@@ -100,7 +109,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP50() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries > 1)? log[(int)(logged_entries * 0.50 - 1)]: -1;
     }
@@ -110,7 +119,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP95() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries >= 100)? log[(int)(logged_entries * 0.95 - 1)]: -1;
     }
@@ -120,7 +129,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP99() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries >= 100)? log[(int)(logged_entries * 0.99 - 1)]: -1;
     }
@@ -130,7 +139,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP99_9() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries >= 1000)? log[(int)(logged_entries * 0.999 - 1)]: -1;
     }
@@ -140,7 +149,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP99_99() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries >= 10000)? log[(int)(logged_entries * 0.9999 - 1)]: -1;
     }
@@ -150,7 +159,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP99_999() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return (logged_entries >= 100000)? log[(int)(logged_entries * 0.99999 - 1)]: -1;
     }
@@ -160,7 +169,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   long getP100() {
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
       return log[logged_entries - 1];
     }
@@ -173,7 +182,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
 
     if (logged_entries > 0) {
       if (needs_preparation) {
-        prep_for_reporting();
+        prep_for_reporting(null);
       }
 
       long p100     = getP100();

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
@@ -169,19 +169,19 @@ class ServerLog extends ExtrememObject {
   }
 
   void prepareToReport(String thread_label) {
-    String label = (_dump_xact_response_times)? thread_label + ":xact_response_times": null;
+    String label = (_dump_xact_response_times)? thread_label + ":SalesTransactionResponseTimes": null;
     xact_response_times.prep_for_reporting(label);
 
-    label = (_dump_history_response_times)? thread_label + ":history_response_times": null;
+    label = (_dump_history_response_times)? thread_label + ":BrowsingHistoryResponseTimes": null;
     history_response_times.prep_for_reporting(label);
 
-    label = (_dump_customer_response_times)? thread_label + ":customer_response_times": null;
+    label = (_dump_customer_response_times)? thread_label + ":CustomerReplacementResponseTimes": null;
     customer_response_times.prep_for_reporting(label);
 
-    label = (_dump_product_response_times)? thread_label + ":product_response_times": null;
+    label = (_dump_product_response_times)? thread_label + ":ProductReplacementResponseTimes": null;
     product_response_times.prep_for_reporting(label);
 
-    label = (_dump_do_nothing_response_times)? thread_label + ":do_nothing_response_times": null;
+    label = (_dump_do_nothing_response_times)? thread_label + ":ServerDoNothingResponseTimes": null;
     do_nothing_response_times.prep_for_reporting(label);
   }
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
@@ -38,7 +38,19 @@ class ServerLog extends ExtrememObject {
   int total_do_nothings;
   ResponseTimeMeasurements do_nothing_response_times;
 
+  final boolean _dump_xact_response_times;
+  final boolean _dump_history_response_times;
+  final boolean _dump_customer_response_times;
+  final boolean _dump_product_response_times;
+  final boolean _dump_do_nothing_response_times;
+
   ServerLog(ExtrememThread t, LifeSpan ls, int response_time_measurements) {
+    this(t, ls, response_time_measurements, false, false, false, false, false);
+  }
+
+  ServerLog(ExtrememThread t, LifeSpan ls, int response_time_measurements,
+            boolean dump_xact_tallies, boolean dump_history_tallies, boolean dump_customer_tallies,
+            boolean dump_product_tallies, boolean dump_do_nothing_tallies) {
     super(t, ls);
 
     sales_xact = new RelativeTimeMetrics(t, ls);
@@ -52,6 +64,12 @@ class ServerLog extends ExtrememObject {
     customer_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
     product_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
     do_nothing_response_times = new ResponseTimeMeasurements(t, ls, response_time_measurements);
+
+    _dump_xact_response_times = dump_xact_tallies;
+    _dump_history_response_times = dump_history_tallies;
+    _dump_customer_response_times = dump_customer_tallies;
+    _dump_product_response_times = dump_product_tallies;
+    _dump_do_nothing_response_times = dump_do_nothing_tallies;
 
     MemoryLog log = t.memoryLog();
     // Account for reference fields sales_xact, expire_history,
@@ -148,6 +166,23 @@ class ServerLog extends ExtrememObject {
     do_nothing_response_times.addToLog(delta_microseconds);
     now.garbageFootprint(t);
     delta.garbageFootprint(t);
+  }
+
+  void prepareToReport(String thread_label) {
+    String label = (_dump_xact_response_times)? thread_label + ":xact_response_times": null;
+    xact_response_times.prep_for_reporting(label);
+
+    label = (_dump_history_response_times)? thread_label + ":history_response_times": null;
+    history_response_times.prep_for_reporting(label);
+
+    label = (_dump_customer_response_times)? thread_label + ":customer_response_times": null;
+    customer_response_times.prep_for_reporting(label);
+
+    label = (_dump_product_response_times)? thread_label + ":product_response_times": null;
+    product_response_times.prep_for_reporting(label);
+
+    label = (_dump_do_nothing_response_times)? thread_label + ":do_nothing_response_times": null;
+    do_nothing_response_times.prep_for_reporting(label);
   }
 
   void report(ExtrememThread t, String label, boolean reportCSV) {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
@@ -58,7 +58,10 @@ class ServerThread extends ExtrememThread {
       this.accumulator = accumulator;
       this.alloc_accumulator = alloc_accumulator;
       this.garbage_accumulator = garbage_accumulator;
-      this.history = new ServerLog(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements());
+      this.history = new ServerLog(this, LifeSpan.NearlyForever, config.ResponseTimeMeasurements(),
+                                   config.DumpSalesTransactionResponseTimes(), config.DumpBrowsingHistoryResponseTimes(),
+                                   config.DumpCustomerReplacementResponseTimes(), config.DumpProductReplacementResponseTimes(),
+                                   config.DumpServerDoNothingResponseTimes());
 
       // Account for reference fields label, all_products,
       // all_customers, sales_queue, browsing_queue,
@@ -242,7 +245,7 @@ class ServerThread extends ExtrememThread {
       next_release_time.changeLifeSpan(this, LifeSpan.TransientShort);
     }
     Trace.msg(2, "Server ", label, " terminating.  Time is up.");
-
+    history.prepareToReport(getLabel());
     // We accumulate accumulator even if reporting individual threads
     accumulator.accumulate(history);
     if (config.ReportIndividualThreads())

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
@@ -92,8 +92,13 @@ class ServerThread extends ExtrememThread {
     while (true) {
       // If the simulation will have ended before we wake up, don't
       // even bother to sleep.
-      if (next_release_time.compare(end_simulation_time) >= 0)
+      if (next_release_time.compare(end_simulation_time) >= 0) {
+        // Wait one period beyond end simulation time to make sure all Customer and Server  work is completed
+        // before we begin report generation.
+        AbsoluteTime end_execution_time = end_simulation_time.addRelative(this, config.LongestPeriod());
+        end_execution_time.sleep(this);
         break;
+      }
 
       AbsoluteTime now = next_release_time.sleep(this);
       now.garbageFootprint(this);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
@@ -94,10 +94,14 @@ class UpdateThread extends ExtrememThread {
     long replaced_products_micros_total = 0;
 
     while (true) {
-      // If the simulation will have ended before we wake up, don't
-      // even bother to sleep.
-      if (next_release_time.compare(end_simulation_time) >= 0)
+      // If the simulation will have ended before we wake up, don't schedule another iteration.
+      if (next_release_time.compare(end_simulation_time) >= 0) {
+        // Wait one period beyond end simulation time to make sure all Customer and Server work is completed
+        // before we begin report generation.
+        AbsoluteTime end_execution_time = end_simulation_time.addRelative(this, config.LongestPeriod());
+        end_execution_time.sleep(this);
         break;
+      }
 
       AbsoluteTime now = next_release_time.sleep(this);
       AbsoluteTime after = now;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/UpdateThread.java
@@ -96,6 +96,9 @@ class UpdateThread extends ExtrememThread {
     while (true) {
       // If the simulation will have ended before we wake up, don't schedule another iteration.
       if (next_release_time.compare(end_simulation_time) >= 0) {
+
+        Report.output("UpdateThread: ", getLabel(), " is winding down");
+
         // Wait one period beyond end simulation time to make sure all Customer and Server work is completed
         // before we begin report generation.
         AbsoluteTime end_execution_time = end_simulation_time.addRelative(this, config.LongestPeriod());
@@ -185,12 +188,17 @@ class UpdateThread extends ExtrememThread {
     }
     Trace.msg(2, "Server ", label, " terminating.  Time is up.");
 
+    Report.output("UpdateThread: ", getLabel(), " has finished simulation");
+
     updateReport(customers_rebuild_count, replaced_customers_min, replaced_customers_max, replaced_customers_total,
                  replaced_customers_micros_min, replaced_customers_micros_max, replaced_customers_micros_total,
                  products_rebuild_count, replaced_products_min, replaced_products_max, replaced_products_total,
                  replaced_products_micros_min, replaced_products_micros_max, replaced_products_micros_total);
 
     this.report(this);
+
+
+    Report.output("UpdateThread: ", getLabel(), " has finished reporting");
   }
 
   synchronized void updateReport(long customers_rebuild_count, long replaced_customers_min, long replaced_customers_max,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Do not begin report processing until after all CustomerThreads and all ServerThreads have had a chance to finish their last iteration of processing.  This change was motivated by discovering that the report processing performed by some threads was causing a spike in allocation while other threads were still performing their final transactions.  When this spike resulted in a degenerated cycle, the extra long stop-the-world pause would skew response time percentiles.
2. Add options to allow the tallies of measured response times to be reported for each threads individually.  The measurements are reported in chronological order.  This helps diagnose when in the history of particular threads the longer delays are experienced.  (eg. if p99.999 latency is reported as 8183, search this log to see when and how often 8183 appears.). This option can also be used to accumulate results from multiple executions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
