### PR TITLE
Improve warmup to optimize logging methods

### DIFF
--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerLog.java
@@ -96,6 +96,43 @@ class CustomerLog extends ExtrememObject {
    return prepare_response_times;
   }
 
+  void reset() {
+    preparer.reset();
+    purchaser.reset();
+    saver.reset();
+    abandoner.reset();
+    loser.reset();
+
+    engagements = 0;
+
+    min_any = Integer.MAX_VALUE;
+    max_any = 0;
+    total_any = 0;
+
+    min_all = Integer.MAX_VALUE;
+    max_all = 0;
+    total_all = 0;
+
+    min_saved = Integer.MAX_VALUE;
+    max_saved = 0;
+    total_previously_saved = 0;
+
+    min_selection = Integer.MAX_VALUE;
+    max_selection = 0;
+    total_selection = 0;
+
+    total_purchased = 0;
+    total_saved = 0;
+    total_abandoned = 0;
+    total_do_nothings = 0;
+
+    prepare_response_times.reset();
+    purchase_response_times.reset();
+    save_for_later_response_times.reset();
+    abandonment_response_times.reset();
+    do_nothing_response_times.reset();
+  }
+
   // This information is redundant with purchaser.  I'll gather it
   // here, and ignore it when logging purchases.
   void logPrepareToThink(CustomerThread t, AbsoluteTime release,
@@ -195,7 +232,7 @@ class CustomerLog extends ExtrememObject {
   }
 
   void prepareToReport(String thread_label) {
-      String label = (_dump_prepare_response_times)? thread_label + ":PreparationResponseTimes": null;
+    String label = (_dump_prepare_response_times)? thread_label + ":PreparationResponseTimes": null;
     prepare_response_times.prep_for_reporting(label);
 
     label = (_dump_purchase_response_times)? thread_label + ":PurchaseResponseTimes": null;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/CustomerThread.java
@@ -106,8 +106,12 @@ class CustomerThread extends ExtrememThread {
       Customer customer = all_customers.selectRandomCustomer(this);
       now.garbageFootprint(this);
 
-      if (!logging && (now.compare(start_logging_time) >= 0)) {
-        logging = true;
+      if (!logging) {
+        // Exercise reset() during warmup time
+        history.reset();
+        if (now.compare(start_logging_time) >= 0) {
+          logging = true;
+        }
       }
 
       // In an earlier implementation, termination of the thread was
@@ -193,15 +197,11 @@ class CustomerThread extends ExtrememThread {
         
         // else, search came up empty.  wait for next period.
         Trace.msg(4, "Customer Thread ", label, " matched no customers");
-        if (logging) {
-          history.logNoChoice(this, next_release_time);
-        }
+        history.logNoChoice(this, next_release_time);
 
         AbsoluteTime end_think = next_release_time.addRelative(this, this.think_time);
         end_think.changeLifeSpan(this, LifeSpan.TransientShort);
-        if (logging) {
-          history.logPrepareToThink(this, next_release_time, all_count, any_count, saved_count);
-        }
+        history.logPrepareToThink(this, next_release_time, all_count, any_count, saved_count);
         end_think.sleep(this);
         end_think.garbageFootprint(this);
       } else {
@@ -221,9 +221,7 @@ class CustomerThread extends ExtrememThread {
 
         AbsoluteTime end_think = next_release_time.addRelative(this, this.think_time);
         end_think.changeLifeSpan(this, LifeSpan.TransientShort);
-        if (logging) {
-          history.logPrepareToThink(this, next_release_time, all_count, any_count, saved_count);
-        }
+        history.logPrepareToThink(this, next_release_time, all_count, any_count, saved_count);
         end_think.sleep(this);
         end_think.garbageFootprint(this);
 
@@ -282,9 +280,7 @@ class CustomerThread extends ExtrememThread {
             // SalesTransaction object as garbage.  This is the same
             // process used even if the associated customer or product
             // becomes decommissioned before the sale is transacted.
-            if (logging) {
-              history.logPurchase(this, end_think);
-            }
+            history.logPurchase(this, end_think);
             break;
 
           case SaveProductForLater:
@@ -317,9 +313,7 @@ class CustomerThread extends ExtrememThread {
             // as eligible for garbage collection by the
             // Customer.prepareForDemise() method that executes when
             // the customer is decommissioned.
-            if (logging) {
-              history.log4Later(this, end_think);
-            }
+            history.log4Later(this, end_think);
             break;
             
           case AbandonProduct:
@@ -327,9 +321,7 @@ class CustomerThread extends ExtrememThread {
             selected.garbageFootprint(this);
 
             Trace.msg(4, "Customer Thread ", label, ", chose abandon");
-            if (logging) {
-              history.logAbandonment(this, end_think);
-            }
+            history.logAbandonment(this, end_think);
         }
       }
       next_release_time.garbageFootprint(this);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTimeMetrics.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/RelativeTimeMetrics.java
@@ -121,6 +121,22 @@ class RelativeTimeMetrics extends ExtrememObject {
                    BucketCount * (Util.SizeOfInt + Util.SizeOfLong));
   }
 
+  void reset() {
+    for (int i = 0; i < BucketCount; i++) {
+      buckets[i] = 0;
+      bucket_bounds[i] = 0;
+    }
+    sis = Long.MAX_VALUE;
+    fblb = 0;
+    lbhb = 0;
+    fbi= 0;
+    sis = 0;
+    lis = 0;
+    biu = 0;
+    total_entries = 0;
+    accumulated_microseconds = 0;
+  }
+
   void addToLog(RelativeTimeMetrics other) {
     int index = other.fbi;
     boolean seen_sis = false;

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ResponseTimeMeasurements.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ResponseTimeMeasurements.java
@@ -18,7 +18,7 @@ class ResponseTimeMeasurements extends ExtrememObject {
   private int first_entry;
 
   private long max_logged;
-  private long min_logged;
+  private long min_logged = Long.MAX_VALUE;
 
   // Each log entry is typically represented in microsecond units.
   private final long[] log;
@@ -47,6 +47,14 @@ class ResponseTimeMeasurements extends ExtrememObject {
     log.accumulate(ls, MemoryFlavor.ArrayObject, Polarity.Expand, 1);
     log.accumulate(ls, MemoryFlavor.ArrayRSB, Polarity.Expand,
                    total_entries * Util.SizeOfLong);
+  }
+
+  void reset() {
+    logged_entries = 0;
+    first_entry = 0;
+    max_logged = 0;
+    min_logged = Long.MAX_VALUE;
+    needs_preparation = true;
   }
 
   void addToLog(ResponseTimeMeasurements other) {
@@ -87,9 +95,9 @@ class ResponseTimeMeasurements extends ExtrememObject {
   public void prep_for_reporting(String label) {
     if (label != null) {
       Report.acquireReportLock();
-      Report.output(label);
+      Report.output(label, ", entries: ", Long.toString(logged_entries));
       for (int i = 0; i < logged_entries; i++) {
-        Report.output(Long.toString(log[i]));
+        Report.output(Long.toString(log[(first_entry + i) % total_entries]));
       }
       Report.releaseReportLock();
     }

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerLog.java
@@ -88,6 +88,41 @@ class ServerLog extends ExtrememObject {
                    Polarity.Expand, 17 * Util.SizeOfInt);
   }
 
+  void reset() {
+    sales_xact.reset();
+    expire_history.reset();
+    replace_customers.reset();
+    replace_products.reset();
+    do_nothing.reset();
+
+    xact_batches = 0;;
+    min_xact_per_batch = Integer.MAX_VALUE;
+    max_xact_per_batch = 0;;
+    total_xact = 0;
+    xact_response_times.reset();
+
+    history_batches = 0;;
+    min_history_per_batch = Integer.MAX_VALUE;
+    max_history_per_batch = 0;
+    total_histories = 0;;
+    history_response_times.reset();
+
+    customer_batches = 0;
+    min_customer_per_batch = Integer.MAX_VALUE;
+    max_customer_per_batch = 0;
+    total_customers = 0;
+    customer_response_times.reset();
+
+    product_batches = 0;
+    min_product_per_batch = Integer.MAX_VALUE;
+    max_product_per_batch = 0;
+    total_products = 0;
+    product_response_times.reset();
+
+    total_do_nothings = 0;
+    do_nothing_response_times.reset();
+  }
+
   void logTransactions(ExtrememThread t, AbsoluteTime release, int count) {
     xact_batches++;
     if (count > max_xact_per_batch)

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/ServerThread.java
@@ -113,8 +113,12 @@ class ServerThread extends ExtrememThread {
       if (now.compare(end_simulation_time) >= 0)
         break;
 
-      if (!logging && (now.compare(start_logging_time) >= 0)) {
-        logging = true;
+      if (!logging) {
+        // Exercise reset() during warmup time
+        history.reset();
+        if (now.compare(start_logging_time) >= 0) {
+          logging = true;
+        }
       }
 
       Trace.msg(4, "Server ", label, ": attention: ", Integer.toString(attention));
@@ -153,9 +157,7 @@ class ServerThread extends ExtrememThread {
           }
           Trace.msg(4, "Server ", label, ": processed sales transactions: ",
                     Integer.toString(transaction_count));
-          if (logging) {
-            history.logTransactions(this, next_release_time, transaction_count);
-          }
+          history.logTransactions(this, next_release_time, transaction_count);
           break;
         case 1:
           // Statistically, the number of BrowsingHistory instances that
@@ -177,9 +179,7 @@ class ServerThread extends ExtrememThread {
           }
           Trace.msg(4, "Server ", label, ": browsing_expirations: ",
                     Integer.toString(browsing_expirations));
-          if (logging) {
-            history.logHistories(this, next_release_time, browsing_expirations);
-          }
+          history.logHistories(this, next_release_time, browsing_expirations);
           break;
         case 2:
           if (next_release_time.compare(customer_replacement_time) >= 0) {
@@ -200,14 +200,10 @@ class ServerThread extends ExtrememThread {
             Trace.msg(4, "Server ", label, ": replaced ",
                       Integer.toString(config.CustomerReplacementCount()),
                       " customers");
-            if (logging) {
-              history.logCustomers(this, next_release_time, config.CustomerReplacementCount());
-            }
+            history.logCustomers(this, next_release_time, config.CustomerReplacementCount());
           } else {
             Trace.msg(4, "Server ", label, ": too early to replace customers");
-            if (logging) {
-              history.logDoNothings(this, next_release_time);
-            }
+            history.logDoNothings(this, next_release_time);
           }
           break;
         case 3:
@@ -223,14 +219,10 @@ class ServerThread extends ExtrememThread {
                                                     LifeSpan.TransientShort);
             Trace.msg(4, "Server ", label, ": replaced products: ",
                       Integer.toString(config.ProductReplacementCount()));
-            if (logging) {
-              history.logProducts(this, next_release_time, config.ProductReplacementCount());
-            }
+            history.logProducts(this, next_release_time, config.ProductReplacementCount());
           } else {
             Trace.msg(4, "Server ", label, ": too early to replace products");
-            if (logging) {
-              history.logDoNothings(this, next_release_time);
-            }
+            history.logDoNothings(this, next_release_time);
           }
           break;
         default:


### PR DESCRIPTION
On large workload with 6000 CustomerThreads and 512 GB heap size, we found that initial log entries for PrepareResponseTimes are over 1.7s, regardless of how long we set WarmupDuration.  We diagnosed that once logging is turned on, the logging methods themselves become hot and a long delay is associated with JIT compiling these methods.

This PR causes the logging methods to be invoked even during warmup and then resets the logs to initial empty state when warmup is finished.  The log reset methods are also exercised during warmup.