### PR TITLE
Add support for variable data base sizes

### DIFF
--- a/Extremem/README.md
+++ b/Extremem/README.md
@@ -73,6 +73,24 @@ When PhasedUpdates is true, a dedicated background thread alternates between reb
 databases.  Each time it finishes building a database, it waits PhasedUpdateInterval amount of time before it begins
 to rebuild the other database.
 
+### *-dNumCustomersVariancePercent=0*
+
+When PhasedUpdates is true, before we rebuild the customer data base for each phased update, we adjust the size of the Customer
+data base by a random percent no greater than this value, either larger or smaller.
+The representation of the Customer data base generally uses two humongous arrays to represent its
+customer names and customer map information.  By varying the sizes of these humongous arrays, we increase the probability that
+humongous allocations may experience fragmentation challenges. When the Customer data base randomly increases, we generate
+random new Customer identities.  When it shrinks, we delete random customers.
+
+### *-dNumProductsVariancePercent=0*
+
+When PhasedUpdates is true, before we rebuild the Products data base for each phased percent, we adjust the size of the Products
+data base by a random percent no greater than this value, either larger or smaller.
+The representation of the Products data base generally uses a humongous array to represent
+product identities. By varying the sizes of this humongous array, we increase the probability that humongous
+allocations may experience fragmentation challenges. When the Products data base randomly increases, we generate
+random new Product descriptions.  When it shrinks, we delete random products.
+
 ### *-dInitializationDelay=50ms*
 
 It is important to complete all initialization of all global data structures before beginning to execute the experimental workload threads.  If

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -98,8 +98,6 @@ class Configuration {
 
   static final int DefaultPhasedUpdateIntervalSeconds = 60;
 
-
-
   static final long DefaultDurationMinutes = 10;
   static final long DefaultWarmupSeconds = 0;
 
@@ -1419,6 +1417,12 @@ class Configuration {
     Report.output("NumCustomers,", s);
     Util.abandonEphemeralString(t, l);
 
+    s = Integer.toString(NumCustomersVariancePercent);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("NumCustomersVariancePercent,", s);
+    Util.abandonEphemeralString(t, l);
+
     s = Integer.toString(KeywordSearchCount);
     l = s.length();
     Util.ephemeralString(t, l);
@@ -1453,6 +1457,12 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("NumProducts,", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(NumProductsVariancePercent);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("NumProductsVariancePercent,", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ProductNameLength);
@@ -1680,6 +1690,13 @@ class Configuration {
     Report.output("                                   Number (NumCustomers): ", s);
     Util.abandonEphemeralString(t, l);
 
+    s = Integer.toString(NumCustomersVariancePercent);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("                  Variance (NumCustomersVariancePercent): ", s);
+    Util.abandonEphemeralString(t, l);
+
+
     s = Integer.toString(KeywordSearchCount);
     l = s.length();
     Util.ephemeralString(t, l);
@@ -1721,6 +1738,12 @@ class Configuration {
     l = s.length();
     Util.ephemeralString(t, l);
     Report.output("                                    Number (NumProducts): ", s);
+    Util.abandonEphemeralString(t, l);
+
+    s = Integer.toString(NumProductsVariancePercent);
+    l = s.length();
+    Util.ephemeralString(t, l);
+    Report.output("                   Variance (NumProductsVariancePercent): ", s);
     Util.abandonEphemeralString(t, l);
 
     s = Integer.toString(ProductNameLength);

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Configuration.java
@@ -91,10 +91,14 @@ class Configuration {
   static final int DefaultBrowsingExpirationMinutes = 10;
   static final int DefaultCustomerReplacementPeriodSeconds = 60;
   static final int DefaultCustomerReplacementCount = 16;
+  static final int DefaultNumCustomersVariancePercent = 0;
+  static final int DefaultNumProductsVariancePercent = 0;
   static final int DefaultProductReplacementPeriodSeconds = 90;
   static final int DefaultProductReplacementCount = 64;
 
   static final int DefaultPhasedUpdateIntervalSeconds = 60;
+
+
 
   static final long DefaultDurationMinutes = 10;
   static final long DefaultWarmupSeconds = 0;
@@ -113,7 +117,9 @@ class Configuration {
   private int MaxP99_999CustomerPrepMicroseconds;
   private int MaxP100CustomerPrepMicroseconds;
   private int NumCustomers;
+  private int NumCustomersVariancePercent;
   private int NumProducts;
+  private int NumProductsVariancePercent;
   private int ProductNameLength;
   private int ProductDescriptionLength;
   private int ProductReviewLength;
@@ -205,9 +211,10 @@ class Configuration {
                    Polarity.Expand, 1);
 
     // Account for
-    //  24 int fields: DictionarySize, ResponseTimeMeasurements,
+    //  26 int fields: DictionarySize, ResponseTimeMeasurements,
     //                 MaxArrayLength, MaxP???CustomerPrepMicroseconds (7 fields),
-    //                 NumCustomers, NumProducts, ProductNameLength,
+    //                 NumCustomers, NumCustomersVariancePercent,
+    //                 NumProducts, NumProductsVariancePercent, ProductNameLength,
     //                 ProductDescriptionLength, ProductReviewLength,
     //                 RandomSeed, KeywordSearchCount,
     //                 CustomerThreads, ServerThreads, 
@@ -219,7 +226,7 @@ class Configuration {
     //   2 float fields: BuyThreshold, SaveForLaterThreshold;
     //   2 boolean fields: ReportIndividualThreads, ReportCSV
     log.accumulate(LifeSpan.NearlyForever, MemoryFlavor.ObjectRSB,
-                   Polarity.Expand, 24 * Util.SizeOfInt +
+                   Polarity.Expand, 26 * Util.SizeOfInt +
                    2 * Util.SizeOfFloat + 2 * Util.SizeOfBoolean);
 
     // Account for 11 reference fields: args, dictionary,
@@ -257,7 +264,9 @@ class Configuration {
     MaxP99_999CustomerPrepMicroseconds = DefaultMaxP99_999CustomerPrepMicroseconds;
     MaxP100CustomerPrepMicroseconds = DefaultMaxP100CustomerPrepMicroseconds;
     NumCustomers = DefaultNumCustomers;
+    NumCustomersVariancePercent = DefaultNumCustomersVariancePercent;
     NumProducts = DefaultNumProducts;
+    NumProductsVariancePercent = DefaultNumProductsVariancePercent;
     ProductNameLength = DefaultProductNameLength;
     ProductDescriptionLength = DefaultProductDescriptionLength;
     ProductReviewLength = DefaultProductReviewLength;
@@ -358,7 +367,9 @@ class Configuration {
     "MaxP99_999CustomerPrepMicroseconds",
     "MaxP100CustomerPrepMicroseconds",
     "NumCustomers",
+    "NumCustomersVariancePercent",
     "NumProducts",
+    "NumProductsVariancePercent",
     "ProductDescriptionLength",
     "ProductNameLength",
     "ProductReplacementCount",
@@ -612,51 +623,61 @@ class Configuration {
           break;
         }
       case 14:
+        if (keyword.equals("NumCustomersVariancePercent")) {
+          NumCustomersVariancePercent = ui;
+          break;
+        }
+      case 15:
         if (keyword.equals("NumProducts")) {
           NumProducts = ui;
           break;
         }
-      case 15:
+      case 16:
+        if (keyword.equals("NumProductsVariancePercent")) {
+          NumProductsVariancePercent = ui;
+          break;
+        }
+      case 17:
         if (keyword.equals("ProductDescriptionLength")) {
           ProductDescriptionLength = ui;
           break;
         }
-      case 16:
+      case 18:
         if (keyword.equals("ProductNameLength")) {
           ProductNameLength = ui;
           break;
         }
-      case 17:
+      case 19:
         if (keyword.equals("ProductReplacementCount")) {
           ProductReplacementCount = ui;
           break;
         }
-      case 18:
+      case 20:
         if (keyword.equals("ProductReviewLength")) {
           ProductReviewLength = ui;
           break;
         }
-      case 19:
+      case 21:
         if (keyword.equals("RandomSeed")) {
           RandomSeed = ui;
           break;
         }
-      case 20:
+      case 22:
         if (keyword.equals("ResponseTimeMeasurements")) {
           ResponseTimeMeasurements = ui;
           break;
         }
-      case 21:
+      case 23:
         if (keyword.equals("SalesTransactionQueueCount")) {
           SalesTransactionQueueCount = ui;
           break;
         }
-      case 22:
+      case 24:
         if (keyword.equals("SelectionCriteriaCount")) {
           SelectionCriteriaCount = ui;
           break;
         }
-      case 23:
+      case 25:
         if (keyword.equals("ServerThreads")) {
           ServerThreads = ui;
           break;
@@ -843,8 +864,30 @@ class Configuration {
     if (NumProducts < 1)
       usage("NumProducts must be greater or equal to 1");
 
+    if (((NumProductsVariancePercent != 0) || (NumProductsVariancePercent != 00)) && !PhasedUpdates) {
+      usage("Only override defaults for NumProductsVariancePercent and NumProductsVariancePercent if PhasedUpdates");
+    }
+
+    if (NumProductsVariancePercent > 99) {
+      usage("NumProductsVariancePercent must be <= 99");
+    }
+
+    long max_products = (long) NumProducts + (long) (NumProductsVariancePercent * 0.01 * NumProducts);
+    if (max_products > (long) Integer.MAX_VALUE) {
+      usage("NumProducts + Variance must be less than or equal to Integer.MAX_VALUE");
+    }
+
     if (NumCustomers < 1)
       usage("NumCustomers must be greater or equal to 1");
+
+    if (NumCustomersVariancePercent > 99) {
+      usage("NumCustomersVariancePercent must be <= 99");
+    }
+
+    long max_customers = (long) NumCustomers + (long) (NumCustomersVariancePercent * 0.01 * NumCustomers);
+    if (max_customers > (long) Integer.MAX_VALUE) {
+      usage("NumCustomers + Variance must be less than or equal to Integer.MAX_VALUE");
+    }
 
     RelativeTime Zero = new RelativeTime(t);
     if (PhasedUpdateInterval.compare(Zero) == 0) {
@@ -1038,9 +1081,17 @@ class Configuration {
   int NumCustomers() {
     return NumCustomers;
   }
+
+  int NumCustomersVariancePercent() {
+    return NumCustomersVariancePercent;
+  }
   
   int NumProducts() {
     return NumProducts;
+  }
+  
+  int NumProductsVariancePercent() {
+    return NumProductsVariancePercent;
   }
   
   int ProductNameLength() {

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Customers.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Customers.java
@@ -162,6 +162,40 @@ class Customers extends ExtrememObject {
     return Character.toUpperCase(input.charAt(0)) + input.substring(1);
   }
 
+  // This service is invoked only by Phased update rebuild Customers.  No lock is necessary.
+  private String randomDistinctName(ExtrememThread t, HashMap<String, Customer> existing_customers) {
+    String full_name;
+    final Polarity Grow = Polarity.Expand;
+    do {
+      // Potentially infinite loop terminates as soon as we randomly generate a name that is not already in the Customer data
+      // base.  Will normally not require more than a single pass, but having a "very small" dictionary and a very large number of
+      // customers could cause excessive iteration here.
+
+      String first = capitalize(t, config.arbitraryWord(t));
+      int first_len = first.length();
+      String last = capitalize(t, config.arbitraryWord(t));
+      int last_len = last.length();
+
+      // ignore the StringBuilder allocations.  Assume optimized out.
+      full_name = first + " " + last;
+      int capacity = Util.ephemeralStringBuilder(t, first_len);
+      capacity = Util.ephemeralStringBuilderAppend(t, first_len, capacity, 1);
+      capacity = Util.ephemeralStringBuilderAppend(t, first_len, capacity,
+                                                   last_len);
+      int full_name_length = first_len + last_len + 1;
+      Util.ephemeralStringBuilderToString(t, full_name_length, capacity);
+      Util.abandonEphemeralString(t, first_len);
+      Util.abandonEphemeralString(t, last_len);
+
+      if (existing_customers.get(full_name) == null) {
+        // Caller will convert returned String from Ephemeral
+        return full_name;
+      } else {
+        Util.abandonEphemeralString(t, full_name_length);
+      }
+    } while (true);
+  }
+
   // The thread that invokes this method already holds a read or
   // write lock, if necessary.
   private String randomDistinctName (ExtrememThread t) {
@@ -193,8 +227,9 @@ class Customers extends ExtrememObject {
       if (customer_map.get(full_name) == null) {
         // Caller will convert returned String from Ephemeral
         return full_name;
-      } else
+      } else {
         Util.abandonEphemeralString(t, full_name_length);
+      }
     } while (true);
   }
 
@@ -214,8 +249,8 @@ class Customers extends ExtrememObject {
     Customer result;
     if (config.PhasedUpdates()) {
       // no synchronization necessary here
-      int index = t.randomUnsignedInt() % config.NumCustomers();
       CurrentCustomersData frozen_state = getCurrentData();
+      int index = t.randomUnsignedInt() % frozen_state.customerNames().length();
       String name = frozen_state.customerNames().get(index);
       result = frozen_state.customerMap().get(name);
     } else if (config.FastAndFurious()) {
@@ -274,19 +309,44 @@ class Customers extends ExtrememObject {
 
     Arraylet<String> new_customer_names;
     HashMap<String, Customer> new_customer_map;
-    int num_customers = config.NumCustomers();
-    int capacity = Util.computeHashCapacity(num_customers, DefaultLoadFactor, Util.InitialHashMapArraySize);
+    int num_customers = customer_names.length();
     long tally = 0;
 
+    // Negative value of customer_increase denotes customer decrease.
+    int customer_variance = 0;
+    if (config.NumCustomersVariancePercent() > 0) {
+      double  r = (t.randomDouble() * 2) - 1.0;
+      customer_variance = (int) ((r * config.NumCustomersVariancePercent() / 100.0) * config.NumCustomers());
+    }
+
+    int new_customer_count = config.NumCustomers() + customer_variance;
+    int customer_increase = new_customer_count - num_customers;
+
+    String s1 = Long.toString(new_customer_count);
+    String s2 = Long.toString(customer_increase);
+    Util.ephemeralString(t, s1.length());
+    Util.ephemeralString(t, s2.length());
+    if (config.NumCustomersVariancePercent() > 0) {
+      if (config.ReportCSV()) {
+        Report.output("Rebuilding Customer Database customers, ", s1, ", delta, ", s2);
+      } else {
+        Report.output("Rebuilding Customer Database with ", s1, " customers, delta: ", s2);
+      }
+    }
+    int capacity = Util.computeHashCapacity(new_customer_count, DefaultLoadFactor, Util.InitialHashMapArraySize);
     LifeSpan ls = this.intendedLifeSpan();
-    new_customer_names = new Arraylet<String>(t, ls, config.MaxArrayLength(), num_customers);
+    new_customer_names = new Arraylet<String>(t, ls, config.MaxArrayLength(), (int) new_customer_count);
     new_customer_map = new HashMap<String, Customer>(capacity, DefaultLoadFactor);
 
-    // First, copy the existing data base
-    for (int i = 0; i < num_customers; i++) {
+    // First, copy the existing data base, but do not copy entries that should be deleted.
+    // If customer_increase < 0, we skip over the first -customer_increase entries.
+    int next_customer_index = 0;
+    int start_index = (customer_increase < 0)? 0 - customer_increase: 0;
+    for (int i = start_index; i < num_customers; i++) {
       String customer_name = customer_names.get(i);
-      new_customer_names.set(i, customer_name);
-      new_customer_map.put(customer_name, customer_map.get(customer_name));
+      Customer customer = customer_map.get(customer_name);
+      new_customer_names.set(next_customer_index++, customer_name);
+      new_customer_map.put(customer_name, customer);
     }
 
     // Then, modify the data base according to instructions in the change log.
@@ -294,18 +354,47 @@ class Customers extends ExtrememObject {
     while ((change = change_log.pull()) != null) {
       tally++;
       int replacement_index = change.index();
-      Customer replacement_customer = change.customer();
-      String replacement_customer_name = replacement_customer.name();
-      if (new_customer_map.get(replacement_customer_name) == null) {
-        String obsolete_name = new_customer_names.get(replacement_index);
-        new_customer_map.remove(obsolete_name);
-        new_customer_names.set(replacement_index, replacement_customer_name);
-        new_customer_map.put(replacement_customer_name, replacement_customer);
-        // Don't bother to expire the old customer or expunge it from save-for-later queues.  That will happen when the
-        // expiration time is reached, at which time the object will become garbage.
+      if (customer_increase < 0) {
+        if (replacement_index + customer_increase >= 0) {
+          replacement_index += customer_increase; // adding negative number here.
+        } else {
+          // Sentinel denotes this change applies to a Customer that no longer exists.
+          replacement_index = -1;
+        }
       }
-      // else, in the very unlikely event that this new name is redundant with an existing name, skip the
-      // customer replacement request.
+      // Note that a replacement index may be greater than new_customer_count in the case that the replacement was processed
+      // during the previous rebuild cycle and that previous rebuild produced a smaller number of Customers than had existed
+      // prior to that rebuild.
+      if (replacement_index >= new_customer_count) {
+        replacement_index = -1;
+      }
+      if (replacement_index >= 0) {
+        Customer replacement_customer = change.customer();
+        String replacement_customer_name = replacement_customer.name();
+        if (new_customer_map.get(replacement_customer_name) == null) {
+          String original_customer_name = new_customer_names.get(replacement_index);
+          new_customer_map.remove(original_customer_name);
+          new_customer_names.set(replacement_index, replacement_customer_name);
+          new_customer_map.put(replacement_customer_name, replacement_customer);
+          // Don't bother to expire the old customer or expunge it from save-for-later queues.  That will happen when the
+          // expiration time is reached, at which time the object will become garbage.
+        }
+        // else, the replacement customer name collides with an existing customer name in new Customer data base,
+        // so we ignore this replacement request.
+      }
+      // else, this change applies to a Customer that no longer exists; nothing to do
+    }
+
+    // Expand the new_customer data base with randomly generated entries.
+    while (next_customer_index < new_customer_count) {
+      String new_customer_name = randomDistinctName(t, new_customer_map);
+      long new_customer_no;
+      synchronized (this) {
+        new_customer_no = next_customer_no++;
+      }
+      Customer new_customer = new Customer(t, LifeSpan.NearlyForever, new_customer_name, new_customer_no);
+      new_customer_names.set(next_customer_index++, new_customer_name);
+      new_customer_map.put(new_customer_name, new_customer);
     }
     establishUpdatedDataBase(t, new_customer_names, new_customer_map);
 

--- a/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
+++ b/Extremem/src/main/java/com/amazon/corretto/benchmark/extremem/Products.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.benchmark.extremem;
 
+import java.util.HashMap;
 import java.util.TreeMap;
 
 /**
@@ -1045,41 +1046,89 @@ class Products extends ExtrememObject {
     long tally = 0;
 
     LifeSpan ls = this.intendedLifeSpan();
-    int num_products = config.NumProducts();
-    new_product_ids = new ArrayletOflong(t, ls, config.MaxArrayLength(), num_products);
+    int num_products = product_ids.length();
+    int product_variance = 0;
+    if (config.NumProductsVariancePercent() > 0) {
+      double  r = (t.randomDouble() * 2) - 1.0;
+      product_variance = (int) ((r * config.NumProductsVariancePercent() / 100.0) * config.NumProducts());
+    }
+
+    int new_product_count = config.NumProducts() + product_variance;
+    int product_increase = new_product_count - num_products;
+    String s1 = Long.toString(new_product_count);
+    String s2 = Long.toString(product_increase);
+    Util.ephemeralString(t, s1.length());
+    Util.ephemeralString(t, s2.length());
+    if (config.NumProductsVariancePercent() > 0) {
+      if (config.ReportCSV()) {
+        Report.output("Rebuilding Product Database products, ", s1, ", delta, ", s2);
+      } else {
+        Report.output("Rebuilding Product Database with ", s1, " products, delta: ", s2);
+      }
+    }
+    new_product_ids = new ArrayletOflong(t, ls, config.MaxArrayLength(), new_product_count);
     new_product_map = new TreeMap<Long, Product>();
     new_name_index = new TreeMap<String, ExtrememHashSet<Long>>();
     new_description_index = new TreeMap<String, ExtrememHashSet<Long>>();
 
-    // First, copy the existing data base
-    for (int i = 0; i < num_products; i++) {
+    // First, copy the existing data base, but do not copy entries that should be deleted.
+    // If product_increase < 0, we skip over the first -product_increase entries.
+    int next_product_index = 0;
+    int start_index = (product_increase < 0)? 0 - product_increase: 0;
+    for (int i = start_index; i < num_products; i++) {
       long product_id = product_ids.get(i);
       Product product = product_map.get(product_id);
-      new_product_ids.set(i, product_id);
+      new_product_ids.set(next_product_index++, product_id);
       new_product_map.put(product_id, product);
     }
 
     // Then, modify the data base according to content of the change log.
     ChangeLogNode change;
     while ((change = change_log.pull()) != null) {
-      int replacement_index = change.index();
-      long replacement_product_id = product_ids.get(replacement_index);
       tally++;
+      int replacement_index = change.index();
+      if (product_increase < 0) {
+        if (replacement_index + product_increase >= 0) {
+          replacement_index += product_increase; // adding negative number here.
+        } else {
+          // Sentinel denotes this change applies to a Customer that no longer exists.
+          replacement_index = -1;
+        }
+      }
+      // Note that a replacement index may be greater than new_product_count in the case that the replacement was processed
+      // during the previous rebuild cycle and that previous rebuild produced a smaller number of Products than had existed
+      // prior to that rebuild.
+      if (replacement_index >= new_product_count) {
+        replacement_index = -1;
+      }
+      if (replacement_index >= 0) {
+        long original_product_id = new_product_ids.get(replacement_index);
+        Product replacement_product = change.product();
+        long replacement_product_id = replacement_product.id();
+        new_product_map.remove(original_product_id);
+        new_product_ids.set(replacement_index, replacement_product_id);
+        new_product_map.put(replacement_product_id, replacement_product);
+      }
+      // else, this change applies to a Product that no longer exists; nothing to do.
+    }
 
-      new_product_map.remove(replacement_product_id);
-
-      Product new_product = change.product();
-      long new_product_id = new_product.id();
-      new_product_ids.set(replacement_index, new_product_id);
-      new_product_map.put(new_product_id, new_product);
+    while (next_product_index < new_product_count) {
+      // Expand the new_products data base with a randomly generated entry
+      String name = randomName(t);
+      String description = randomDescription(t);
+      long new_id = nextUniqId();
+      Product new_product = new Product(t, LifeSpan.NearlyForever, new_id, name, description);
+      new_product_ids.set(next_product_index++, new_id);
+      new_product_map.put(new_id, new_product);
     }
 
     // Now, build the replacement indexes
-    for (int i = 0; i < num_products; i++) {
+    for (int i = 0; i < new_product_count; i++) {
       long product_id = new_product_ids.get(i);
       Product product = new_product_map.get(product_id);
       addToIndicesPhasedUpdates(t, product, new_name_index, new_description_index);
     }
+
     establishUpdatedDataBase(t, new_product_ids, new_product_map, new_name_index, new_description_index);
 
     now = AbsoluteTime.now(t);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds two new command-line parameters to allow each variation in the size of Customer and Products data bases, each time these data bases are rebuilt. By varying the sizes of the data bases, we increase the probability that fragmentation causes humongous allocations to fail.  Use these options to test GC mechanisms that are designed to improve handling of humongous allocations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
